### PR TITLE
Adding AppImage build

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
         "build:64": "yarn run build:ts && yarn run build:res && electron-builder --x64",
         "build:universal": "yarn run build:ts && yarn run build:res && electron-builder --universal",
         "build": "yarn run build:ts && yarn run build:res && electron-builder",
+        "build:appimage": "yarn run build:ts && yarn run build:res && electron-builder -l appimage --publish=never",
         "build:ts": "tsc",
         "build:res": "ts-node scripts/copy-res.ts",
         "docker:setup": "docker build --platform linux/amd64 -t element-desktop-dockerbuild dockerbuild",


### PR DESCRIPTION
`yarn build:appimage` should build the AppImage version of riot-desktop 

eg.

```bash
$ yarn build:appimage

yarn run v1.22.4
$ electron-builder -l appimage --publish=never
  • electron-builder  version=22.6.1 os=5.4.35-1-lts
  • loaded configuration  file=package.json ("build" field)
  • writing effective config  file=dist/builder-effective-config.yaml
  • packaging       platform=linux arch=x64 electron=8.0.3 appOutDir=dist/linux-unpacked
  • building        target=AppImage arch=x64 file=dist/Riot-1.6.1.AppImage

```