### PR TITLE
Only set badgeCount on Mac/Linux because Windows is made of fail

### DIFF
--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -325,7 +325,12 @@ process.on('uncaughtException', function(error) {
 
 let focusHandlerAttached = false;
 ipcMain.on('setBadgeCount', function(ev, count) {
-    app.badgeCount = count;
+    if (process.platform !== 'win32') {
+        // only set badgeCount on Mac/Linux, the docs say that only those platforms support it but turns out Electron
+        // has some Windows support too, and in some Windows environments this leads to two badges rendering atop
+        // each other. See https://github.com/vector-im/element-web/issues/16942
+        app.badgeCount = count;
+    }
     if (count === 0 && mainWindow) {
         mainWindow.flashFrame(false);
     }


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/16942

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Only set badgeCount on Mac/Linux because Windows is made of fail ([\#271](https://github.com/vector-im/element-desktop/pull/271)). Fixes vector-im/element-web#16942.<!-- CHANGELOG_PREVIEW_END -->