### PR TITLE
Add background color to mainWindow to prevent white flashes while launching

### DIFF
--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -925,7 +925,7 @@ app.on('ready', async () => {
     const preloadScript = path.normalize(`${__dirname}/preload.js`);
     mainWindow = global.mainWindow = new BrowserWindow({
         // https://www.electronjs.org/docs/faq#the-font-looks-blurry-what-is-this-and-what-can-i-do
-        backgroundColor: '#fff',
+        backgroundColor: '#16191e',
 
         icon: iconPath,
         show: false,
@@ -1015,7 +1015,9 @@ app.on('window-all-closed', () => {
 });
 
 app.on('activate', () => {
-    mainWindow.show();
+    mainWindow.once('ready-to-show', () => {
+        mainWindow.show();
+    });
 });
 
 function beforeQuit() {

--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -19,7 +19,7 @@ limitations under the License.
 
 // Squirrel on windows starts the app with various flags as hooks to tell us when we've been installed/uninstalled etc.
 import "./squirrelhooks";
-import { app, ipcMain, powerSaveBlocker, BrowserWindow, Menu, autoUpdater, protocol, dialog } from "electron";
+import { app, ipcMain, powerSaveBlocker, BrowserWindow, Menu, autoUpdater, protocol, dialog, nativeTheme } from "electron";
 import AutoLaunch from "auto-launch";
 import path from "path";
 import windowStateKeeper from 'electron-window-state';
@@ -925,7 +925,7 @@ app.on('ready', async () => {
     const preloadScript = path.normalize(`${__dirname}/preload.js`);
     mainWindow = global.mainWindow = new BrowserWindow({
         // https://www.electronjs.org/docs/faq#the-font-looks-blurry-what-is-this-and-what-can-i-do
-        backgroundColor: '#16191e',
+        backgroundColor: nativeTheme.shouldUseDarkColors ? '#16191e' : '#fff',
 
         icon: iconPath,
         show: false,


### PR DESCRIPTION
Type: defect

Fix vector-im/element-desktop#817

notes: Add background color to mainWindow to prevent white flashes while launching. Got solution from [official docs](https://www.electronjs.org/docs/latest/api/browser-window#showing-window-gracefully).

Signed-off-by: Pedro Costa pedroluiz51@gmail.com

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Add background color to mainWindow to prevent white flashes while launching. Got solution from [official docs](https ([\#274](https://github.com/vector-im/element-desktop/pull/274)). Fixes #817. Contributed by @pedr0luiz.<!-- CHANGELOG_PREVIEW_END -->