### PR TITLE
Draft: multiple accounts

### DIFF
--- a/src/instances.ts
+++ b/src/instances.ts
@@ -1,0 +1,279 @@
+import { BrowserView, Event, Input, dialog, session, Session, ipcMain, BrowserWindow } from "electron";
+import * as path from 'path';
+import webContentsHandler from './webcontents-handler';
+import { _t } from './language-helper';
+import Store from 'electron-store';
+import { resize } from "./resizer";
+import { emitInstanceUpdate } from "./menu-view";
+import { Seshat } from "matrix-seshat";
+
+/**
+ * The format stored in electron-config.json
+ */
+interface InstanceStoreData {
+    key: string;
+    matrixId: string;
+    avatar: string|null;
+    // isLegacyDefaultSession?: boolean;
+}
+
+let lastAsarPath: string;
+
+/**
+ * All Element instances added to Electron
+ */
+const instances: ElementInstance[] = [];
+
+const exitShortcuts: Array<(input: Input, platform: string) => boolean> = [
+    (input, platform) => platform !== 'darwin' && input.alt && input.key.toUpperCase() === 'F4',
+    (input, platform) => platform !== 'darwin' && input.control && input.key.toUpperCase() === 'Q',
+    (input, platform) => platform === 'darwin' && input.meta && input.key.toUpperCase() === 'Q',
+];
+
+const warnBeforeExit = (event: Event, input: Input): void => {
+    const shouldWarnBeforeExit = global.store.get('warnBeforeExit', true);
+    const exitShortcutPressed =
+        input.type === 'keyDown' && exitShortcuts.some(shortcutFn => shortcutFn(input, process.platform));
+
+    if (shouldWarnBeforeExit && exitShortcutPressed) {
+        const shouldCancelCloseRequest = dialog.showMessageBoxSync(global.mainWindow, {
+            type: "question",
+            buttons: [_t("Cancel"), _t("Close Element")],
+            message: _t("Are you sure you want to quit?"),
+            defaultId: 1,
+            cancelId: 0,
+        }) === 0;
+
+        if (shouldCancelCloseRequest) {
+            event.preventDefault();
+        }
+    }
+};
+
+const handleFileProtocolRequest = (asarPath: string) => (
+    request: Electron.ProtocolRequest,
+    callback: (response: Electron.ProtocolResponse) => void,
+) => {
+    if (request.method !== 'GET') {
+        callback({ error: -322 }); // METHOD_NOT_SUPPORTED from chromium/src/net/base/net_error_list.h
+        return null;
+    }
+
+    const parsedUrl = new URL(request.url);
+    if (parsedUrl.protocol !== 'vector:') {
+        callback({ error: -302 }); // UNKNOWN_URL_SCHEME
+        return;
+    }
+    if (parsedUrl.host !== 'vector') {
+        callback({ error: -105 }); // NAME_NOT_RESOLVED
+        return;
+    }
+
+    const target = parsedUrl.pathname.split('/');
+
+    // path starts with a '/'
+    if (target[0] !== '') {
+        callback({ error: -6 }); // FILE_NOT_FOUND
+        return;
+    }
+
+    if (target[target.length - 1] == '') {
+        target[target.length - 1] = 'index.html';
+    }
+
+    let baseDir: string;
+    if (target[1] === 'webapp') {
+        baseDir = asarPath;
+    } else {
+        callback({ error: -6 }); // FILE_NOT_FOUND
+        return;
+    }
+
+    // Normalise the base dir and the target path separately, then make sure
+    // the target path isn't trying to back out beyond its root
+    baseDir = path.normalize(baseDir);
+
+    const relTarget = path.normalize(path.join(...target.slice(2)));
+    if (relTarget.startsWith('..')) {
+        callback({ error: -6 }); // FILE_NOT_FOUND
+        return;
+    }
+    const absTarget = path.join(baseDir, relTarget);
+
+    callback({
+        path: absTarget,
+    });
+};
+
+export class ElementInstance {
+    key: string;
+    matrixId: string|null;
+    avatar: string|null;
+    view: BrowserView;
+    session: Session;
+    eventIndex: Seshat = null;
+    badgeCount = 0;
+    isLoaded = false;
+    constructor(key: string, matrixId: string, avatar: string, asarPath: string) {
+        this.key = key;
+        this.matrixId = matrixId;
+        this.avatar = avatar;
+        this.session = session.fromPartition('persist:'+key);
+        this.session.protocol.registerFileProtocol('vector', handleFileProtocolRequest(asarPath));
+
+        const preloadScript = path.normalize(`${__dirname}/preload.js`);
+        this.view = new BrowserView({
+            webPreferences: {
+                preload: preloadScript,
+                nodeIntegration: false,
+                //sandbox: true, // We enable sandboxing from app.enableSandbox() above
+                contextIsolation: true,
+                webgl: true,
+                session: this.session,
+            },
+        });
+
+        this.view.webContents.loadURL('vector://vector/webapp/');
+
+        // Handle spellchecker
+        // For some reason spellCheckerEnabled isn't persisted, so we have to use the store here
+        this.session.setSpellCheckerEnabled(global.store.get("spellCheckerEnabled", true));
+
+        this.view.webContents.on('before-input-event', warnBeforeExit);
+        webContentsHandler(this.view.webContents);
+        // this.view.webContents.openDevTools({mode: 'detach'})
+
+        this.view.webContents.once('did-finish-load', () => {
+            this.isLoaded = true;
+
+            // periodically pull current loggedin account
+            // TODO: get notified somehow instead of pulling
+            setInterval(( ) => {
+                this.updateAccountData();
+            }, 3000);
+        });
+    }
+    private async updateAccountData() {
+        let updated = false;
+        const isLoggedIn = await this.view.webContents.executeJavaScript('!!window.mxMatrixClientPeg.get()');
+        if (isLoggedIn) {
+            const matrixId = await this.view.webContents.executeJavaScript(
+                'window.mxMatrixClientPeg.get()?.getUserId() || null',
+            );
+            if (this.matrixId !== matrixId) {
+                this.matrixId = matrixId || null;
+                updated = true;
+            }
+
+            // get avatar as base64
+            // TODO: is there a cleaner way (without triggering any requests)?
+            const avatar = await this.view.webContents.executeJavaScript(`
+                (function () {
+                    let img = document.querySelector('img.mx_UserMenu_userAvatar_BaseAvatar')
+                    if(!img) return null
+                    img.setAttribute('crossOrigin', 'anonymous');
+                    let c = document.createElement('canvas');
+                    c.height = img.naturalHeight;
+                    c.width = img.naturalWidth;
+                    c.getContext('2d').drawImage(img, 0, 0, c.width, c.height);
+                    return c.toDataURL()
+                })()
+            `);
+            if (this.avatar !== avatar && avatar !== 'data:,') {
+                this.avatar = avatar || null;
+                updated = true;
+            }
+        } else {
+            if (this.matrixId) updated = true;
+            this.matrixId = null;
+            this.avatar = null;
+        }
+
+        if (updated) {
+            emitInstanceUpdate();
+            const store = global.store as Store;
+            const storedInstances = store.get('instances') as InstanceStoreData[];
+            const i = storedInstances.find(i => i.key === this.key);
+            i.matrixId = this.matrixId;
+            i.avatar = this.avatar;
+            store.set('instances', storedInstances);
+        }
+    }
+}
+/**
+ * creates a new instance and stores it in the electron-config.json
+ * called by the instance menu
+ */
+export function createInstance(key: string) {
+    createInstanceView(key, null, null, lastAsarPath, global.mainWindow);
+    selectInstance(key);
+    emitInstanceUpdate();
+    const store = global.store as Store;
+    const storedInstances = store.get('instances') as InstanceStoreData[];
+    storedInstances.push({
+        key,
+        matrixId: null,
+        avatar: null,
+    });
+    store.set('instances', storedInstances);
+}
+
+/**
+ * creates a new ElementInstance containing an electron BrowserView
+ */
+export function createInstanceView(
+    key: string, matrixId: string, avatar: string, asarPath: string, window: BrowserWindow,
+) {
+    // remeber for later use
+    lastAsarPath = asarPath;
+
+    const ins = new ElementInstance(key, matrixId, avatar, asarPath);
+    instances.push(ins);
+    window.addBrowserView(ins.view);
+}
+
+/**
+ * loads all instances stored in the electron-config.json
+ */
+export function loadInstances(store: Store, asarPath: string, window: BrowserWindow) {
+    if (!store.has('instances')) {
+        // TODO: find out, whether default session was already used
+        // -> start with partition directly or reuse the existing default session
+        store.set('instances', [
+            {
+                key: 'test',
+                matrixId: '@test:livingutopia.org',
+                avatar: null,
+                // isLegacyDefaultSession: true,
+            },
+        ]);
+    }
+
+    const instanceList = store.get('instances') as InstanceStoreData[];
+    if (!instanceList) {
+        console.log('no instance found');
+        // TODO: automatically create a new instance
+        return;
+    }
+    const activeInstance = store.get('activeInstance', instanceList[0].key) as string|undefined;
+    for (const ins of instanceList) {
+        createInstanceView(ins.key, ins.matrixId, ins.avatar, asarPath, window);
+    }
+    selectInstance(activeInstance);
+    ipcMain.emit('instance-update');
+}
+
+export function selectInstance(key: string) {
+    const ins = instances.find(i => i.key === key);
+    if (!ins) {
+        console.error(`Instance '${key}' does not exist`);
+        return;
+    }
+    (global.mainWindow as BrowserWindow).setTopBrowserView(ins.view);
+    global.currentView = ins.view;
+    resize();
+}
+
+export function getInstances() {
+    return instances;
+}

--- a/src/menu-view.ts
+++ b/src/menu-view.ts
@@ -1,0 +1,51 @@
+import { BrowserView, BrowserWindow, ipcMain } from "electron";
+import * as path from 'path';
+import { selectInstance, getInstances, createInstance } from "./instances";
+
+let menu: BrowserView;
+
+ipcMain.on('select-instance', (_ev, key) => {
+    selectInstance(key);
+});
+
+ipcMain.handle('get-instances', () => {
+    return getInstances().map(ins => ({
+        key: ins.key,
+        matrixId: ins.matrixId,
+        avatar: ins.avatar,
+    }));
+});
+
+ipcMain.on('create-instance', () => {
+    console.log('create-instance');
+
+    // TODO: find better way to name instances
+    // is it possible to rename session partitions to matrixId later once loggedin?
+    const key = 'instance'+Math.random();
+    createInstance(key);
+});
+
+/**
+ * let menu know, that something in the list of instances has changed
+ */
+export function emitInstanceUpdate() {
+    menu.webContents.send('instance-update');
+}
+
+export function createMenuView(window: BrowserWindow): BrowserView {
+    menu = new BrowserView({
+        webPreferences: {
+            preload: path.normalize(`${__dirname}/menu/preload.js`),
+        },
+    });
+    menu.setBounds({
+        x: 0,
+        y: 0,
+        height: 800,
+        width: 50,
+    });
+    menu.webContents.loadFile('./src/menu/index.html');
+    menu.webContents.openDevTools({ mode: 'detach' });
+    window.addBrowserView(menu);
+    return menu;
+}

--- a/src/menu/index.html
+++ b/src/menu/index.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width">
+  <style>
+    html {
+        background-color: #d5d5d5;
+    }
+    .instance-button {
+        border-radius: 8px;
+        display: block;
+        -webkit-box-align: center;
+        -ms-flex-align: center;
+        align-items: center;
+        padding: 4px;
+        width: 20px;
+        height: 20px;
+        cursor: pointer;
+        margin-left: 2px;
+        border: 2px solid #aaa;
+        text-align: center;
+        margin-bottom: 2px;
+        background-position: center;
+        background-size: cover;
+    }
+    .instance-button.add {
+        border-color: rgba(13,100,100, 0.1);
+    }
+    .instance-button img {
+        width: 100%;
+    }
+  </style>
+</head>
+
+<body>
+  <div id="app"></div>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react/16.0.0/umd/react.production.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/16.0.0/umd/react-dom.production.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/6.26.0/babel.min.js"></script>
+
+  <!-- 
+    rather a quick POC than a real, properly coded component
+   -->
+  <script type="text/jsx">
+    class MenuItem extends React.Component {
+        onClick = () => {
+            electronAPI.selectInstance(this.props.id)
+        }
+        render() {
+            console.log(this.props)
+            return (<a onClick={this.onClick} class="instance-button" title={this.props.matrixId} style={{backgroundImage: `url(${this.props.avatar})`}}>
+                {this.props.avatar ? null : this.props.matrixId.slice(1,2).toUpperCase() }
+            </a>)
+        }
+    }
+    class MenuItemAdd extends React.Component {
+        onClick = () => {
+            if(this.props.id) {
+                electronAPI.selectInstance(this.props.id)
+            } else {
+                electronAPI.createInstance()
+            }
+        }
+        render() {
+            return (<a onClick={this.onClick} class="instance-button add" title="Add another account">
+                +
+            </a>)
+        }
+    }
+    class Menu extends React.Component {
+      constructor(props) {
+        super(props);
+
+        this.state = {
+            instances: []
+        }
+      }
+      componentDidMount() {
+        electronAPI.onInstanceUpdate( () => {
+            console.log('onInstanceUpdate')
+            this.loadInstances();
+        })
+        this.loadInstances()
+      }
+      async loadInstances() {
+        const instances = await electronAPI.getInstances()
+        console.log('got instances', instances)
+        this.setState({
+            instances
+        })
+      }
+      render() {
+        const instances = this.state.instances.filter(i => i.matrixId)
+        const newInstance = this.state.instances.find(i => !i.matrixId)
+        return (<div>
+            {instances.map(i => (
+                <MenuItem key={i.key} id={i.key} matrixId={i.matrixId} avatar={i.avatar} />
+            ))}
+            <MenuItemAdd id={newInstance ? newInstance.key : null} />
+        </div>);
+      }
+    }
+    ReactDOM.render(<Menu />, document.getElementById('app'));
+  </script>
+</body>
+
+</html>

--- a/src/menu/preload.ts
+++ b/src/menu/preload.ts
@@ -1,0 +1,8 @@
+import { contextBridge, ipcRenderer } from 'electron';
+
+contextBridge.exposeInMainWorld('electronAPI', {
+    getInstances: () => ipcRenderer.invoke('get-instances'),
+    onInstanceUpdate: (callback) => ipcRenderer.on('instance-update', callback),
+    selectInstance: (id: string) => ipcRenderer.send('select-instance', id),
+    createInstance: () => ipcRenderer.send('create-instance'),
+});

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -49,7 +49,8 @@ function processUrl(url: string): void {
     urlToLoad.hash = parsed.hash;
 
     console.log("Opening URL: ", urlToLoad.href);
-    global.mainWindow.loadURL(urlToLoad.href);
+    // TODO: ask for instance to open with
+    global.currentView.loadURL(urlToLoad.href);
 }
 
 function readStore(): object {

--- a/src/resizer.ts
+++ b/src/resizer.ts
@@ -1,0 +1,19 @@
+
+// TODO: can electron tile it in that way automatically?
+export function resize() {
+    setTimeout( () => {
+        const contentBounds = global.mainWindow.getContentBounds();
+        global.currentView.setBounds({
+            x: 50,
+            y: 0,
+            width: contentBounds.width-50,
+            height: contentBounds.height,
+        });
+        global.menuView.setBounds({
+            x: 0,
+            y: 0,
+            width: 50,
+            height: contentBounds.height,
+        });
+    });
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -48,8 +48,8 @@ export const Settings: Record<string, Setting> = {
         },
         async write(value: any): Promise<void> {
             global.store.set('autoHideMenuBar', !value);
-            global.mainWindow.autoHideMenuBar = !value;
-            global.mainWindow.setMenuBarVisibility(value);
+            // global.mainWindow.autoHideMenuBar = !value;
+            // global.mainWindow.setMenuBarVisibility(value);
         },
     },
     "Electron.showTrayIcon": { // not supported on macOS

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -61,40 +61,40 @@ export function create(config: IConfig): void {
     trayIcon.on('click', toggleWin);
 
     let lastFavicon = null;
-    global.mainWindow.webContents.on('page-favicon-updated', async function(ev, favicons) {
-        if (!favicons || favicons.length <= 0 || !favicons[0].startsWith('data:')) {
-            if (lastFavicon !== null) {
-                global.mainWindow.setIcon(defaultIcon);
-                trayIcon.setImage(defaultIcon);
-                lastFavicon = null;
-            }
-            return;
-        }
+    // global.mainWindow.webContents.on('page-favicon-updated', async function(ev, favicons) {
+    //     if (!favicons || favicons.length <= 0 || !favicons[0].startsWith('data:')) {
+    //         if (lastFavicon !== null) {
+    //             global.mainWindow.setIcon(defaultIcon);
+    //             trayIcon.setImage(defaultIcon);
+    //             lastFavicon = null;
+    //         }
+    //         return;
+    //     }
 
-        // No need to change, shortcut
-        if (favicons[0] === lastFavicon) return;
-        lastFavicon = favicons[0];
+    //     // No need to change, shortcut
+    //     if (favicons[0] === lastFavicon) return;
+    //     lastFavicon = favicons[0];
 
-        let newFavicon = nativeImage.createFromDataURL(favicons[0]);
+    //     let newFavicon = nativeImage.createFromDataURL(favicons[0]);
 
-        // Windows likes ico's too much.
-        if (process.platform === 'win32') {
-            try {
-                const icoPath = path.join(app.getPath('temp'), 'win32_element_icon.ico');
-                fs.writeFileSync(icoPath, await pngToIco(newFavicon.toPNG()));
-                newFavicon = nativeImage.createFromPath(icoPath);
-            } catch (e) {
-                console.error("Failed to make win32 ico", e);
-            }
-        }
+    //     // Windows likes ico's too much.
+    //     if (process.platform === 'win32') {
+    //         try {
+    //             const icoPath = path.join(app.getPath('temp'), 'win32_element_icon.ico');
+    //             fs.writeFileSync(icoPath, await pngToIco(newFavicon.toPNG()));
+    //             newFavicon = nativeImage.createFromPath(icoPath);
+    //         } catch (e) {
+    //             console.error("Failed to make win32 ico", e);
+    //         }
+    //     }
 
-        trayIcon.setImage(newFavicon);
-        global.mainWindow.setIcon(newFavicon);
-    });
+    //     trayIcon.setImage(newFavicon);
+    //     global.mainWindow.setIcon(newFavicon);
+    // });
 
-    global.mainWindow.webContents.on('page-title-updated', function(ev, title) {
-        trayIcon.setToolTip(title);
-    });
+    // global.mainWindow.webContents.on('page-title-updated', function(ev, title) {
+    //     trayIcon.setToolTip(title);
+    // });
 }
 
 export function initApplicationMenu(): void {

--- a/src/vectormenu.ts
+++ b/src/vectormenu.ts
@@ -98,7 +98,7 @@ export function buildMenuTemplate(): Menu {
                 // in macOS the Preferences menu item goes in the first menu
                 ...(!isMac ? [{
                     label: _t('Preferences'),
-                    click() { global.mainWindow.webContents.send('preferences'); },
+                    click() { global.currentView.webContents.send('preferences'); },
                 }] : []),
                 {
                     role: 'togglefullscreen',
@@ -153,7 +153,7 @@ export function buildMenuTemplate(): Menu {
                 {
                     label: _t('Preferences') + '…',
                     accelerator: 'Command+,', // Mac-only accelerator
-                    click() { global.mainWindow.webContents.send('preferences'); },
+                    click() { global.currentView.webContents.send('preferences'); },
                 },
                 { type: 'separator' },
                 {


### PR DESCRIPTION
first draft of multiple element instances in the same electron BrowserWindow.

Works so far, but there is still a lot to do (see ToDo list) and I can't promise that I'll find time for that in the next weeks 🙃 

related vector-im/element-web#2320


![Screenrecording showing switching between the instances](https://user-images.githubusercontent.com/10246027/185788380-049cd80f-2855-4328-a776-876bf899773b.gif)


### ToDo's
- [ ] proper react menu with (webpack?) building
- [ ] show badge counts in menu
- [ ] aggregate badge counts for tray
- [ ] open correct instance on notification click
- [ ] make multiple profiles optional (via lab flag?)
- [ ] apply a change in theme to all instances + menu
- [ ] menu i18n
- [ ] menu styling
- [ ] instance chooser for protocol links
- [ ] bring back electrons dropdown menu
- [ ] accessibility
- [ ] how to handle 'page-favicon-updated' and 'page-title-updated' now? (`tray.ts`)
- [ ] tests
- [ ] proper session partition naming, renaming possible?
- [ ] migration of existing sessions

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has none of the required changelog labels.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->