### PR TITLE
Prevent the media lightbox sender info clipping with traffic light on macos

### DIFF
--- a/src/macos-titlebar.ts
+++ b/src/macos-titlebar.ts
@@ -32,6 +32,10 @@ export function setupMacosTitleBar(window: BrowserWindow): void {
                 /* 19px original top value, 32px margin-top above, 12px original margin-top value */
                 top: calc(19px + 32px - 12px) !important;
             }
+            /* Prevent the media lightbox sender info from clipping into the traffic light buttons */
+            .mx_ImageView_info_wrapper {
+                margin-top: 32px;
+            }
             
             /* Mark the splash screen as a drag handle */
             .mx_MatrixChat_splash {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-desktop/issues/1140

<img width="208" alt="image" src="https://github.com/vector-im/element-desktop/assets/2403652/704a11f7-f0c3-4239-b458-ab72a5ed0c66">


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Prevent the media lightbox sender info clipping with traffic light on macos ([\#1141](https://github.com/vector-im/element-desktop/pull/1141)). Fixes #1140.<!-- CHANGELOG_PREVIEW_END -->