### PR TITLE
Add libsqlcipher0 to Depends for DEB packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,10 +165,10 @@
                 "libuuid1",
                 "libsecret-1-0",
                 "libasound2",
-                "libgbm1"
+                "libgbm1",
+                "libsqlcipher0"
             ],
             "recommends": [
-                "libsqlcipher0",
                 "element-io-archive-keyring"
             ]
         },

--- a/scripts/generate-builder-config.ts
+++ b/scripts/generate-builder-config.ts
@@ -112,7 +112,7 @@ async function main(): Promise<number | void> {
 
         if (process.env.SQLCIPHER_BUNDLED) {
             // Remove sqlcipher dependency when using bundled
-            cfg.deb!.recommends = cfg.deb!.recommends?.filter((d) => d !== "libsqlcipher0");
+            cfg.deb!.depends = cfg.deb!.depends?.filter((d) => d !== "libsqlcipher0");
         }
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Ensure your code works with manual testing
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/vector-im/element-desktop/blob/develop/CONTRIBUTING.md))

Based on the information from #1233 I checked for the inclusion of `libsqlcipher0` in Debian-based distributions. Debian itself includes it since Buster (mid 2019), and all currently supported Debian and Ubuntu versions ship it. Checking the package databases of major Debian/Ubuntu derivates (Linux Mint, MX Linux, Pop_OS!, Devuan, antiX) shows them either shipping it too or pulling it from the Ubuntu repos.

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has none of the required changelog labels.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->