### PR TITLE
Enable generic secrets in keytar via ipc

### DIFF
--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -23,6 +23,7 @@ import { randomArray } from "./utils";
 import { Settings } from "./settings";
 import { keytar } from "./keytar";
 import { getDisplayMediaCallback, setDisplayMediaCallback } from "./displayMediaCallback";
+import { getSecretStore } from "./secrets";
 
 ipcMain.on("setBadgeCount", function (_ev: IpcMainEvent, count: number): void {
     if (process.platform !== "win32") {
@@ -145,6 +146,26 @@ ipcMain.on("ipcCall", async function (_ev: IpcMainEvent, payload) {
 
         case "startSSOFlow":
             recordSSOSession(args[0]);
+            break;
+
+        case "getSecret":
+            try {
+                ret = await getSecretStore().getSecret(args[0]);
+            } catch (e) {
+                ret = null;
+            }
+            break;
+        case "saveSecret":
+            try {
+                ret = await getSecretStore().saveSecret(args[0], args[1]);
+            } catch (e) {
+                ret = null;
+            }
+            break;
+        case "destroySecret":
+            try {
+                ret = await getSecretStore().destroySecret(args[0]);
+            } catch (e) {}
             break;
 
         case "getPickleKey":

--- a/src/secrets.ts
+++ b/src/secrets.ts
@@ -1,0 +1,66 @@
+/*
+Copyright 2023 New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { type SafeStorage, safeStorage } from "electron";
+
+/**
+ * Save secrets on a local machine until logout.
+ */
+interface SecretStore {
+    saveSecret(name: string, value: string): Promise<string | null>;
+    getSecret(name: string): Promise<string | null>;
+    destroySecret(name: string): Promise<void>;
+}
+
+class SafeStorageSecretStore implements SecretStore {
+    public constructor(public readonly safeStorage: SafeStorage) { }
+
+    public async saveSecret(name: string, value: string): Promise<string | null> {
+        global.store.set(this.storeKey(name), this.safeStorage.encryptString(value).toString("base64"));
+        return await this.getSecret(this.storeKey(name));
+    }
+    public async getSecret(name: string): Promise<string | null> {
+        return this.safeStorage.decryptString(Buffer.from(global.store.get(this.storeKey(name)) as string, "base64"));
+    }
+    public async destroySecret(name: string): Promise<void> {
+        global.store.delete(this.storeKey(name) as any);
+    }
+
+    private storeKey(name: string): string {
+        return `safeStorage.${name}`;
+    }
+}
+
+class NullSecretStore implements SecretStore {
+    public async saveSecret(): Promise<string | null> { return null; }
+    public async getSecret(): Promise<string | null> { return null; }
+    public async destroySecret(): Promise<void> { }
+}
+
+function createSecretStore(): SecretStore {
+    if (safeStorage.isEncryptionAvailable() && safeStorage.getSelectedStorageBackend() !== "basic_text") {
+        return new SafeStorageSecretStore(safeStorage);
+    }
+    return new NullSecretStore();
+}
+
+let secretStore: SecretStore | null = null;
+export function getSecretStore(): SecretStore {
+    if (!secretStore) {
+        secretStore = createSecretStore();
+    }
+    return secretStore;
+}


### PR DESCRIPTION
This PR implements an extended IPC interface (<https://github.com/vector-im/element-web/pull/26405>) between the electron platform and application. The interface can be used to set, retrieve and destroy arbitrary secrets, similar to saving pickle keys. Notably, these changes allow setting a value for a secret instead of just generating a random one and retrieving it. See also <https://github.com/matrix-org/matrix-react-sdk/pull/11776>.

## Checklist

-   [x] Ensure your code works with manual testing
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/vector-im/element-desktop/blob/develop/CONTRIBUTING.md))

Notes: none

<!-- CHANGELOG_PREVIEW_START -->
---
This change has no change notes, so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->