### PR TITLE
Upgrade to glibc 2.28 in the Docker image for Node20 compatibility

### DIFF
--- a/.github/workflows/build_linux.yaml
+++ b/.github/workflows/build_linux.yaml
@@ -91,12 +91,9 @@ jobs:
               if: steps.cache.outputs.cache-hit != 'true' && inputs.arch == 'arm64'
               run: |
                   set -x
-                  sed -i 's/deb http/deb [arch=amd64] http/g' /etc/apt/sources.list
-                  echo "deb [arch=arm64]  http://deb.debian.org/debian-ports/ buster main multiverse restricted universe" | tee -a /etc/apt/sources.list
-                  echo "deb [arch=arm64]  http://deb.debian.org/debian-ports/ buster-updates main multiverse restricted universe" | tee -a /etc/apt/sources.list
                   dpkg --add-architecture arm64
                   apt-get -qq update
-                  apt-get -qq install --no-install-recommends crossbuild-essential-arm64 libsqlcipher-dev:arm64 libssl-dev:arm64 libsecret-1-dev:arm64 libgnome-keyring-dev:arm64
+                  apt-get -qq install --no-install-recommends crossbuild-essential-arm64 libsqlcipher-dev:arm64 libssl-dev:arm64 libsecret-1-dev:arm64
                   rustup target add aarch64-unknown-linux-gnu
                   mv dockerbuild/aarch64/.cargo .
                   cat dockerbuild/aarch64/.env >> $GITHUB_ENV

--- a/.github/workflows/build_linux.yaml
+++ b/.github/workflows/build_linux.yaml
@@ -92,8 +92,8 @@ jobs:
               run: |
                   set -x
                   sed -i 's/deb http/deb [arch=amd64] http/g' /etc/apt/sources.list
-                  echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ bionic main multiverse restricted universe" | tee -a /etc/apt/sources.list
-                  echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ bionic-updates main multiverse restricted universe" | tee -a /etc/apt/sources.list
+                  echo "deb [arch=arm64]  http://deb.debian.org/debian-ports/ buster main multiverse restricted universe" | tee -a /etc/apt/sources.list
+                  echo "deb [arch=arm64]  http://deb.debian.org/debian-ports/ buster-updates main multiverse restricted universe" | tee -a /etc/apt/sources.list
                   dpkg --add-architecture arm64
                   apt-get -qq update
                   apt-get -qq install --no-install-recommends crossbuild-essential-arm64 libsqlcipher-dev:arm64 libssl-dev:arm64 libsecret-1-dev:arm64 libgnome-keyring-dev:arm64

--- a/dockerbuild/Dockerfile
+++ b/dockerbuild/Dockerfile
@@ -1,5 +1,5 @@
 # Docker image to facilitate building Element Desktop with native bits using a glibc version with broader compatibility
-FROM buildpack-deps:bionic-curl
+FROM buildpack-deps:buster-curl
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/dockerbuild/Dockerfile
+++ b/dockerbuild/Dockerfile
@@ -11,9 +11,9 @@ RUN apt-get -qq update && apt-get -qq dist-upgrade && \
   # python for node-gyp
   # rpm is required for FPM to build rpm package
   # tclsh is required for building SQLite as part of SQLCipher
-  # libsecret-1-dev and libgnome-keyring-dev are required even for prebuild keytar
+  # libsecret-1-dev is required even for prebuild keytar
   apt-get -qq install --no-install-recommends qtbase5-dev bsdtar build-essential autoconf libssl-dev gcc-multilib g++-multilib lzip rpm python libcurl4 git git-lfs ssh unzip tcl \
-  libsecret-1-dev libgnome-keyring-dev \
+  libsecret-1-dev \
   libopenjp2-tools \
   # Used by github actions \
   jq grep file \


### PR DESCRIPTION
Unblocks https://github.com/element-hq/element-desktop/pull/1390

This drops support for Ubuntu 18.04 which ran out of standard support earlier this year.

https://docs.linuxgsm.com/requirements/glibc#distro-glibc-versions
https://wiki.ubuntu.com/Releases

Tested on Debian 10 aarch64

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🦖 Deprecations
 * Upgrade to glibc 2.28 in the Docker image for Node20 compatibility ([\#1391](https://github.com/element-hq/element-desktop/pull/1391)).<!-- CHANGELOG_PREVIEW_END -->