### PR TITLE
Revert "Upgrade to {upload,download}-artifact@v4 for better performance"

### DIFF
--- a/.github/workflows/build_and_deploy.yaml
+++ b/.github/workflows/build_and_deploy.yaml
@@ -127,7 +127,7 @@ jobs:
         environment: packages.element.io
         steps:
             - name: Download artifacts
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v3
 
             - name: Deploy artifacts
               run: |

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -138,7 +138,7 @@ jobs:
             - name: Install Deps
               run: "yarn install --frozen-lockfile"
 
-            - uses: actions/download-artifact@v4
+            - uses: actions/download-artifact@v3
               with:
                   name: ${{ matrix.artifact }}
                   path: dist
@@ -156,9 +156,9 @@ jobs:
                   ELEMENT_DESKTOP_EXECUTABLE: ${{ matrix.executable }}
 
             - name: Upload Artifacts
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v3
               if: always()
               with:
-                  name: ${{ matrix.artifact }}-test-result
+                  name: ${{ matrix.artifact }}
                   path: test_artifacts
                   retention-days: 1

--- a/.github/workflows/build_linux.yaml
+++ b/.github/workflows/build_linux.yaml
@@ -57,7 +57,7 @@ jobs:
 
             - uses: actions/checkout@v3
 
-            - uses: actions/download-artifact@v4
+            - uses: actions/download-artifact@v3
               with:
                   name: webapp
 
@@ -150,7 +150,7 @@ jobs:
 
             - name: Stash deb package
               if: inputs.deploy-mode
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v3
               with:
                   name: linux-sqlcipher-${{ inputs.sqlcipher }}-deb
                   path: dist/*.deb
@@ -178,7 +178,7 @@ jobs:
 
             # We exclude *-unpacked as it loses permissions and the tarball contains it with correct permissions
             - name: Upload Artifacts
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v3
               with:
                   name: ${{ inputs.deploy-mode && 'packages.element.io' || format('linux-{0}-sqlcipher-{1}', inputs.arch, inputs.sqlcipher) }}
                   path: |

--- a/.github/workflows/build_macos.yaml
+++ b/.github/workflows/build_macos.yaml
@@ -38,7 +38,7 @@ jobs:
         steps:
             - uses: actions/checkout@v3
 
-            - uses: actions/download-artifact@v4
+            - uses: actions/download-artifact@v3
               with:
                   name: webapp
 
@@ -151,7 +151,7 @@ jobs:
 
             # We exclude mac-universal as the unpacked app takes forever to upload and zip and dmg already contain it
             - name: Upload Artifacts
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v3
               with:
                   name: ${{ inputs.deploy-mode && 'packages.element.io' || 'macos' }}
                   path: |

--- a/.github/workflows/build_prepare.yaml
+++ b/.github/workflows/build_prepare.yaml
@@ -128,7 +128,7 @@ jobs:
                   echo "| React SDK   | [$REACT_VERSION](https://github.com/matrix-org/matrix-react-sdk/commit/$REACT_VERSION) |" >> $GITHUB_STEP_SUMMARY
                   echo "| JS SDK      | [$JS_VERSION](https://github.com/matrix-org/matrix-js-sdk/commit/$JS_VERSION) |" >> $GITHUB_STEP_SUMMARY
 
-            - uses: actions/upload-artifact@v4
+            - uses: actions/upload-artifact@v3
               with:
                   name: webapp
                   retention-days: 1

--- a/.github/workflows/build_windows.yaml
+++ b/.github/workflows/build_windows.yaml
@@ -60,7 +60,7 @@ jobs:
 
             - uses: actions/checkout@v3
 
-            - uses: actions/download-artifact@v4
+            - uses: actions/download-artifact@v3
               with:
                   name: webapp
 
@@ -197,7 +197,7 @@ jobs:
               working-directory: "dist/install/win32/${{ steps.config.outputs.dir }}"
 
             - name: Upload Artifacts
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v3
               with:
                   name: ${{ inputs.deploy-mode && 'packages.element.io' || format('win-{0}', inputs.arch) }}
                   path: dist


### PR DESCRIPTION
Reverts element-hq/element-desktop#1390

This breaks release/nightly builds as we reuse the `packages.element.io` artifact there.