### PR TITLE
Switch to artifact-v4 and move packages.element.io packing to deploy workflow

### DIFF
--- a/.github/workflows/build_and_deploy.yaml
+++ b/.github/workflows/build_and_deploy.yaml
@@ -58,12 +58,11 @@ jobs:
         name: Windows ${{ matrix.arch }}
         strategy:
             matrix:
-                arch: [x86, x64]
+                arch: [ia32, x64]
         uses: ./.github/workflows/build_windows.yaml
         secrets: inherit
         with:
             sign: true
-            deploy-mode: true
             arch: ${{ matrix.arch }}
             version: ${{ needs.prepare.outputs.nightly-version }}
 
@@ -75,37 +74,25 @@ jobs:
         secrets: inherit
         with:
             sign: true
-            deploy-mode: true
             base-url: https://packages.element.io/${{ needs.prepare.outputs.packages-dir }}
             version: ${{ needs.prepare.outputs.nightly-version }}
 
-    # We do not put these calls into deploy-mode as we do not want it to add to the packages.element.io artifact
-    # We ship this build via reprepro only
     linux:
         if: github.event_name != 'workflow_dispatch' || inputs.linux
         needs: prepare
-        name: Linux ${{ matrix.arch }} (sqlcipher system)
+        name: Linux ${{ matrix.arch }} (sqlcipher ${{ matrix.sqlcipher }})
         strategy:
             matrix:
                 arch: [amd64, arm64]
+                sqlcipher: [system, static]
+                exclude:
+                    - arch: arm64
+                      sqlcipher: static
         uses: ./.github/workflows/build_linux.yaml
         with:
             arch: ${{ matrix.arch }}
             config: ${{ needs.prepare.outputs.config }}
-            sqlcipher: system
-            version: ${{ needs.prepare.outputs.nightly-version }}
-
-    # We ship the static build via static tarball only
-    linux_static:
-        if: github.event_name != 'workflow_dispatch' || inputs.linux
-        needs: prepare
-        name: Linux (sqlcipher static)
-        uses: ./.github/workflows/build_linux.yaml
-        with:
-            arch: amd64
-            deploy-mode: true
-            config: ${{ needs.prepare.outputs.config }}
-            sqlcipher: static
+            sqlcipher: ${{ matrix.sqlcipher }}
             version: ${{ needs.prepare.outputs.nightly-version }}
 
     deploy:
@@ -113,7 +100,6 @@ jobs:
             - prepare
             - macos
             - linux
-            - linux_static
             - windows
         runs-on: ubuntu-latest
         name: Deploy
@@ -127,7 +113,65 @@ jobs:
         environment: packages.element.io
         steps:
             - name: Download artifacts
-              uses: actions/download-artifact@v3
+              uses: actions/download-artifact@v4
+
+            - name: Prepare artifacts for deployment
+              run: |
+                  # Windows
+                  for arch in x64 ia32 arm64
+                  do
+                      if [ -d "win-$arch" ]; then
+                          mkdir -p packages.element.io/{install,update}/win32/$arch
+                          mv win-$arch/squirrel-windows*/*.exe "packages.element.io/install/win32/$arch/"
+                          mv win-$arch/squirrel-windows*/*.nupkg "packages.element.io/update/win32/$arch/"
+                          mv win-$arch/squirrel-windows*/RELEASES "packages.element.io/update/win32/$arch/"
+                      fi
+                  done
+
+                  # macOS
+                  if [ -d macos ]; then
+                      mkdir -p packages.element.io/{install,update}/macos
+                      mv macos/*.dmg packages.element.io/install/macos/
+                      mv macos/*-mac.zip packages.element.io/update/macos/
+                      mv macos/*.json packages.element.io/update/macos/
+                  fi
+
+                  # Linux
+                  if [ -d linux-amd64-sqlcipher-static ]; then
+                      mkdir -p packages.element.io/install/linux/glibc-x86-64
+                      mv linux-amd64-sqlcipher-static/*.tar.gz packages.element.io/install/linux/glibc-x86-64
+                  fi
+
+            # We don't wish to store the installer for every nightly ever, so we only keep the latest
+            - name: "[Nightly] Strip version from installer file"
+              if: needs.prepare.outputs.nightly-version != ''
+              run: |
+                  # Windows
+                  for arch in x64 ia32 arm64
+                  do
+                      [ -d "win-$arch" ] && mv packages.element.io/install/win32/$arch/{*,"Element Nightly Setup"}.exe
+                  done
+
+                  # macOS
+                  [ -d macos ] && mv packages.element.io/install/macos/{*,"Element Nightly"}.dmg
+
+                  # Linux
+                  [ -d linux-amd64-sqlcipher-static ] && mv packages.element.io/install/linux/glibc-x86-64/{*,element-desktop-nightly}.tar.gz
+
+            - name: "[Release] Prepare release latest symlink"
+              if: needs.prepare.outputs.nightly-version == ''
+              run: |
+                  # Windows
+                  for arch in x64 ia32 arm64
+                  do
+                      DIR=packages.element.io/install/win32/$arch [ -d "win-$arch" ] && ln -s "$(find $DIR -type f -iname "*.exe" | xargs -0 -n1 -- basename)" "$DIR/Element Setup.exe"
+                  done
+
+                  # macOS
+                  DIR=packages.element.io/install/macos [ -d macos ] && ln -s "$(find $DIR -type f -iname "*.dmg" | xargs -0 -n1 -- basename)" "$DIR/Element.dmg"
+
+                  # Linux
+                  DIR=packages.element.io/install/glibc-x86-64 [ -d linux-amd64-sqlcipher-static ] && ln -s "$(find $DIR -type f -iname "*.tar.gz" | xargs -0 -n1 -- basename)" "$DIR/element-desktop.tar.gz"
 
             - name: Deploy artifacts
               run: |

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: ./.github/workflows/build_windows.yaml
         strategy:
             matrix:
-                arch: [x64, x86]
+                arch: [x64, ia32]
         with:
             arch: ${{ matrix.arch }}
 
@@ -120,7 +120,7 @@ jobs:
                       prepare_cmd: "sudo apt install ./dist/*.deb"
                     - name: Windows (x86)
                       os: windows
-                      artifact: win-x86
+                      artifact: win-ia32
                       executable: "./dist/win-ia32-unpacked/Element.exe"
                     - name: Windows (x64)
                       os: windows
@@ -138,7 +138,7 @@ jobs:
             - name: Install Deps
               run: "yarn install --frozen-lockfile"
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: ${{ matrix.artifact }}
                   path: dist
@@ -156,9 +156,9 @@ jobs:
                   ELEMENT_DESKTOP_EXECUTABLE: ${{ matrix.executable }}
 
             - name: Upload Artifacts
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               if: always()
               with:
-                  name: ${{ matrix.artifact }}
+                  name: ${{ matrix.artifact }}-test
                   path: test_artifacts
                   retention-days: 1

--- a/.github/workflows/build_linux.yaml
+++ b/.github/workflows/build_linux.yaml
@@ -20,10 +20,6 @@ on:
                 type: string
                 required: true
                 description: "How to link sqlcipher, one of 'system' | 'static'"
-            deploy-mode:
-                type: boolean
-                required: false
-                description: "Whether to arrange artifacts in the arrangement needed for deployment, skipping unrelated ones"
             docker-image:
                 type: string
                 required: false
@@ -57,7 +53,7 @@ jobs:
 
             - uses: actions/checkout@v4
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: webapp
 
@@ -143,39 +139,11 @@ jobs:
               env:
                   ARCH: ${{ steps.config.outputs.arch }}
 
-            - name: Stash deb package
-              if: inputs.deploy-mode
-              uses: actions/upload-artifact@v3
-              with:
-                  name: linux-sqlcipher-${{ inputs.sqlcipher }}-deb
-                  path: dist/*.deb
-                  retention-days: 1
-
-            - name: Prepare artifacts for deployment
-              if: inputs.deploy-mode
-              run: |
-                  mv dist _dist
-                  mkdir -p "dist/install/linux/glibc-x86-64/"
-                  mv _dist/*.tar.gz "dist/install/linux/glibc-x86-64"
-
-            # We don't wish to store the tarball for every nightly ever, so we only keep the latest
-            - name: "[Nightly] Strip version from tarball"
-              if: inputs.deploy-mode && inputs.version != ''
-              run: |
-                  mv dist/install/linux/glibc-x86-64/*.tar.gz "dist/install/linux/glibc-x86-64/element-desktop-nightly.tar.gz"
-
-            - name: "[Release] Prepare release latest symlink"
-              if: inputs.deploy-mode && inputs.version == ''
-              shell: bash
-              run: |
-                  ln -s "$(find . -type f -iname "*.tar.gz" | xargs -0 -n1 -- basename)" "element-desktop.tar.gz"
-              working-directory: "dist/install/linux/glibc-x86-64"
-
             # We exclude *-unpacked as it loses permissions and the tarball contains it with correct permissions
             - name: Upload Artifacts
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
-                  name: ${{ inputs.deploy-mode && 'packages.element.io' || format('linux-{0}-sqlcipher-{1}', inputs.arch, inputs.sqlcipher) }}
+                  name: linux-${{ inputs.arch }}-sqlcipher-${{ inputs.sqlcipher }}
                   path: |
                       dist
                       !dist/*-unpacked/**

--- a/.github/workflows/build_macos.yaml
+++ b/.github/workflows/build_macos.yaml
@@ -23,14 +23,10 @@ on:
                 type: string
                 required: false
                 description: "Whether to sign & notarise the build, requires 'packages.element.io' environment"
-            deploy-mode:
-                type: boolean
-                required: false
-                description: "Whether to arrange artifacts in the arrangement needed for deployment, skipping unrelated ones"
             base-url:
                 type: string
                 required: false
-                description: "The URL to which the output will be deployed, required if deploy-mode is enabled."
+                description: "The URL to which the output will be deployed."
 jobs:
     build:
         runs-on: macos-latest
@@ -38,7 +34,7 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: webapp
 
@@ -104,14 +100,8 @@ jobs:
               env:
                   CSC_IDENTITY_AUTO_DISCOVERY: false
 
-            - name: Prepare artifacts for deployment
-              if: inputs.deploy-mode
+            - name: Generate releases.json
               run: |
-                  mv dist _dist
-                  mkdir -p dist/install/macos dist/update/macos
-                  mv _dist/*-mac.zip dist/update/macos/
-                  mv _dist/*.dmg dist/install/macos/
-
                   PKG_JSON_VERSION=$(cat package.json | jq -r .version)
                   LATEST=$(find dist -type f -iname "*-mac.zip" | xargs -0 -n1 -- basename)
                   # Encode spaces in the URL as Squirrel.Mac complains about bad JSON otherwise
@@ -128,30 +118,18 @@ jobs:
                         },
                       }],
                     }
-                  ' > dist/update/macos/releases.json
+                  ' > dist/releases.json
                   jq -n --arg url "$URL" '
                     { url: $url }
-                  ' > dist/update/macos/releases-legacy.json
+                  ' > dist/releases-legacy.json
               env:
                   VERSION: ${{ inputs.version }}
 
-            # We don't wish to store the installer for every nightly ever, so we only keep the latest
-            - name: "[Nightly] Strip version from installer file"
-              if: inputs.deploy-mode && inputs.version != ''
-              run: |
-                  mv dist/install/macos/*.dmg "dist/install/macos/Element Nightly.dmg"
-
-            - name: "[Release] Prepare release latest symlink"
-              if: inputs.deploy-mode && inputs.version == ''
-              run: |
-                  ln -s "$(find . -type f -iname "*.dmg" | xargs -0 -n1 -- basename)" "Element.dmg"
-              working-directory: "dist/install/macos"
-
-            # We exclude mac-universal as the unpacked app takes forever to upload and zip and dmg already contain it
+            # We exclude mac-universal as the unpacked app takes forever to upload and zip and dmg already contains it
             - name: Upload Artifacts
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
-                  name: ${{ inputs.deploy-mode && 'packages.element.io' || 'macos' }}
+                  name: macos
                   path: |
                       dist
                       !dist/mac-universal/**

--- a/.github/workflows/build_macos.yaml
+++ b/.github/workflows/build_macos.yaml
@@ -101,6 +101,7 @@ jobs:
                   CSC_IDENTITY_AUTO_DISCOVERY: false
 
             - name: Generate releases.json
+              if: inputs.base-url
               run: |
                   PKG_JSON_VERSION=$(cat package.json | jq -r .version)
                   LATEST=$(find dist -type f -iname "*-mac.zip" | xargs -0 -n1 -- basename)

--- a/.github/workflows/build_prepare.yaml
+++ b/.github/workflows/build_prepare.yaml
@@ -128,7 +128,7 @@ jobs:
                   echo "| React SDK   | [$REACT_VERSION](https://github.com/matrix-org/matrix-react-sdk/commit/$REACT_VERSION) |" >> $GITHUB_STEP_SUMMARY
                   echo "| JS SDK      | [$JS_VERSION](https://github.com/matrix-org/matrix-js-sdk/commit/$JS_VERSION) |" >> $GITHUB_STEP_SUMMARY
 
-            - uses: actions/upload-artifact@v3
+            - uses: actions/upload-artifact@v4
               with:
                   name: webapp
                   retention-days: 1

--- a/.github/workflows/build_windows.yaml
+++ b/.github/workflows/build_windows.yaml
@@ -14,7 +14,7 @@ on:
             arch:
                 type: string
                 required: true
-                description: "The architecture to build for, one of 'x64' | 'x86' | 'arm64'"
+                description: "The architecture to build for, one of 'x64' | 'ia32' | 'arm64'"
             version:
                 type: string
                 required: false
@@ -23,10 +23,6 @@ on:
                 type: string
                 required: false
                 description: "Whether to sign & notarise the build, requires 'packages.element.io' environment"
-            deploy-mode:
-                type: boolean
-                required: false
-                description: "Whether to arrange artifacts in the arrangement needed for deployment, skipping unrelated ones"
 jobs:
     build:
         runs-on: windows-latest
@@ -42,25 +38,23 @@ jobs:
                   map: |
                       {
                         "x64": {
-                          "target": "x86_64-pc-windows-msvc",
-                          "dir": "x64"
+                          "target": "x86_64-pc-windows-msvc"
                         },
                         "arm64": {
                           "target": "aarch64-pc-windows-msvc",
                           "build-args": "--arm64",
-                          "arch": "amd64_arm64",
-                          "dir": "arm64"
+                          "arch": "amd64_arm64"
                         },
-                        "x86": {
+                        "ia32": {
                           "target": "i686-pc-windows-msvc",
                           "build-args": "--ia32",
-                          "dir": "ia32"
+                          "arch": "x86"
                         }
                       }
 
             - uses: actions/checkout@v4
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: webapp
 
@@ -169,39 +163,10 @@ jobs:
               run: |
                   . "$env:SIGNTOOL_PATH" verify /pa (get-item ./dist/squirrel-windows*/*.exe)
 
-            - name: Prepare artifacts for deployment
-              if: inputs.deploy-mode
-              shell: bash
-              run: |
-                  mv dist _dist
-                  mkdir -p "dist/install/win32/$DIR/msi" "dist/update/win32/$DIR"
-                  mv _dist/squirrel-windows*/*.exe "dist/install/win32/$DIR"
-                  mv _dist/squirrel-windows*/*.nupkg "dist/update/win32/$DIR/"
-                  mv _dist/squirrel-windows*/RELEASES "dist/update/win32/$DIR/"
-                  # mv _dist/*.msi "dist/install/win32/$DIR/msi/"
-              env:
-                  DIR: ${{ steps.config.outputs.dir }}
-
-            # We don't wish to store the installer for every nightly ever, so we only keep the latest
-            - name: "[Nightly] Strip version from installer file"
-              if: inputs.deploy-mode && inputs.version != ''
-              shell: bash
-              run: |
-                  mv dist/install/win32/$DIR/*.exe "dist/install/win32/$DIR/Element Nightly Setup.exe"
-                  # mv dist/install/win32/$DIR/msi/*.msi "dist/install/win32/$DIR/msi/Element Nightly Setup.msi"
-              env:
-                  DIR: ${{ steps.config.outputs.dir }}
-
-            - name: "[Release] Prepare release latest symlink"
-              if: inputs.deploy-mode && inputs.version == ''
-              shell: bash
-              run: |
-                  ln -s "$(find . -type f -iname "*.exe" | xargs -0 -n1 -- basename)" "Element Setup.exe"
-              working-directory: "dist/install/win32/${{ steps.config.outputs.dir }}"
-
             - name: Upload Artifacts
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
-                  name: ${{ inputs.deploy-mode && 'packages.element.io' || format('win-{0}', inputs.arch) }}
-                  path: dist
+                  name: win-${{ inputs.arch }}
+                  path: |
+                      dist
                   retention-days: 1


### PR DESCRIPTION
This moves concerns around a little and allows us up to 10x the performance of artifact uploads by switching to v4 which drops support for uploading to a single artifact multiple times (inc from multiple runners which we were making use of)

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->