### PR TITLE
Force Element Call video rooms

### DIFF
--- a/element.io/nightly/config.json
+++ b/element.io/nightly/config.json
@@ -50,7 +50,8 @@
     "privacy_policy_url": "https://element.io/cookie-policy",
     "features": {
         "feature_spotlight": true,
-        "feature_video_rooms": true
+        "feature_video_rooms": true,
+        "feature_element_call_video_rooms": true
     },
     "element_call": {
         "url": "https://call.element.dev"


### PR DESCRIPTION
Video rooms are currently using jitsi. The VoiP team is planning to sunset jitsi in the longer term.
As the first step the video rooms (which are a beta feature that needs to be activated) are using EC instead of jitsi.

This PR activates feature_element_call_video_rooms on develop.element.io so that video rooms default to element call instead of jitis.

(existing jitsi video rooms will stay configured with jitsi.)


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->