### PR TITLE
Specify minimum libc version for Debian packages

### DIFF
--- a/electron-builder.js
+++ b/electron-builder.js
@@ -115,6 +115,7 @@ const config = {
             "libsecret-1-0",
             "libasound2",
             "libgbm1",
+            "libc6 (>= 2.28)",
         ],
         recommends: ["libsqlcipher0", "element-io-archive-keyring"],
         fpm: [
@@ -122,8 +123,6 @@ const config = {
             "Replaces: riot-desktop (<< 1.7.0), riot-web (<< 1.7.0)",
             "--deb-field",
             "Breaks: riot-desktop (<< 1.7.0), riot-web (<< 1.7.0)",
-            "--deb-pre-depends",
-            "libc (>= 2.28)",
         ],
     },
     mac: {

--- a/electron-builder.js
+++ b/electron-builder.js
@@ -115,6 +115,7 @@ const config = {
             "libsecret-1-0",
             "libasound2",
             "libgbm1",
+            "libc>=2.28",
         ],
         recommends: ["libsqlcipher0", "element-io-archive-keyring"],
         fpm: [

--- a/electron-builder.js
+++ b/electron-builder.js
@@ -115,7 +115,7 @@ const config = {
             "libsecret-1-0",
             "libasound2",
             "libgbm1",
-            "libc>=2.28",
+            "libc (>= 2.28)",
         ],
         recommends: ["libsqlcipher0", "element-io-archive-keyring"],
         fpm: [

--- a/electron-builder.js
+++ b/electron-builder.js
@@ -115,7 +115,6 @@ const config = {
             "libsecret-1-0",
             "libasound2",
             "libgbm1",
-            "libc (>= 2.28)",
         ],
         recommends: ["libsqlcipher0", "element-io-archive-keyring"],
         fpm: [
@@ -123,6 +122,8 @@ const config = {
             "Replaces: riot-desktop (<< 1.7.0), riot-web (<< 1.7.0)",
             "--deb-field",
             "Breaks: riot-desktop (<< 1.7.0), riot-web (<< 1.7.0)",
+            "--deb-pre-depends",
+            "libc (>= 2.28)",
         ],
     },
     mac: {


### PR DESCRIPTION
We recently upgraded to libc 2.28 and some people on EOL OSes got an upgraded element-desktop which would not start

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Specify minimum libc version for Debian packages ([\#1446](https://github.com/element-hq/element-desktop/pull/1446)).<!-- CHANGELOG_PREVIEW_END -->