### PR TITLE
changed NODE_VERSION to 18.12.0 to resolv version dependencies 

### DIFF
--- a/dockerbuild/Dockerfile
+++ b/dockerbuild/Dockerfile
@@ -34,7 +34,7 @@ ENV LC_ALL C.UTF-8
 
 ENV DEBUG_COLORS true
 ENV FORCE_COLOR true
-ENV NODE_VERSION 16.18.1
+ENV NODE_VERSION 18.12.0
 
 # this package is used for snapcraft and we should not clear apt list - to avoid apt-get update during snap build
 RUN curl --proto "=https" -L https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz | tar xz -C /usr/local --strip-components=1 && \


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Element-Desktop requires nodejs >= 18.0.0 (see package.json) but `NODEJS_VERSION` was set to "16.18.1" in `dockerbuild/Dockerfile`. This MR sets the `NODEJS_VERSION` to "18.12.0". Closes #1470 

## Checklist

-   [x] Ensure your code works with manual testing
-   [x] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/vector-im/element-desktop/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->