### PR TITLE
Bugfix: Failed to save image

### DIFF
--- a/src/webcontents-handler.ts
+++ b/src/webcontents-handler.ts
@@ -33,6 +33,7 @@ import {
 import url from "url";
 import fs from "fs";
 import fetch from "node-fetch";
+import { promisify } from 'node:util'
 import { pipeline } from "stream";
 import path from "path";
 
@@ -165,7 +166,8 @@ function onLinkContextMenu(ev: Event, params: ContextMenuParams, webContents: We
                             const resp = await fetch(url);
                             if (!resp.ok) throw new Error(`unexpected response ${resp.statusText}`);
                             if (!resp.body) throw new Error(`unexpected response has no body ${resp.statusText}`);
-                            pipeline(resp.body, fs.createWriteStream(filePath));
+                            const promisfyPipeline = promisify(pipeline);
+                            promisfyPipeline(resp.body, fs.createWriteStream(filePath));
                         }
                     } catch (err) {
                         console.error(err);

--- a/src/webcontents-handler.ts
+++ b/src/webcontents-handler.ts
@@ -33,7 +33,7 @@ import {
 import url from "url";
 import fs from "fs";
 import fetch from "node-fetch";
-import { promisify } from 'node:util'
+import { promisify } from "util";
 import { pipeline } from "stream";
 import path from "path";
 

--- a/src/webcontents-handler.ts
+++ b/src/webcontents-handler.ts
@@ -33,8 +33,7 @@ import {
 import url from "url";
 import fs from "fs";
 import fetch from "node-fetch";
-import { promisify } from "util";
-import { pipeline } from "stream";
+import { pipeline } from "stream/promises";
 import path from "path";
 
 import { _t } from "./language-helper";
@@ -166,8 +165,7 @@ function onLinkContextMenu(ev: Event, params: ContextMenuParams, webContents: We
                             const resp = await fetch(url);
                             if (!resp.ok) throw new Error(`unexpected response ${resp.statusText}`);
                             if (!resp.body) throw new Error(`unexpected response has no body ${resp.statusText}`);
-                            const promisfyPipeline = promisify(pipeline);
-                            promisfyPipeline(resp.body, fs.createWriteStream(filePath));
+                            await pipeline(resp.body, fs.createWriteStream(filePath));
                         }
                     } catch (err) {
                         console.error(err);


### PR DESCRIPTION
Fixes the error that when saving as image... the file cannot be saved.

Fixes #976

```
TypeError [ERR_INVALID_ARG_TYPE]: The "streams[stream.length - 1]" property must be of type function. Received an instance of WriteStream
at popCallback (node:internal/streams/pipeline:74:3)
at pipeline (node:internal/streams/pipeline:185:37)
at /Users/sra/Documents/element/element-desktop/lib/webcontents-handler.js:153:51
at Generator.next ()
at fulfilled (/Users/sra/Documents/element/element-desktop/lib/webcontents-handler.js:20:58)
at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
code: 'ERR_INVALID_ARG_TYPE'
}
```

## Checklist

-   [x] Ensure your code works with manual testing.
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/vector-im/element-desktop/blob/develop/CONTRIBUTING.md)).
