### PR TITLE
Roll out Rust crypto to 30% of existing users of stable Element Desktop

### DIFF
--- a/element.io/release/config.json
+++ b/element.io/release/config.json
@@ -46,6 +46,6 @@
     "privacy_policy_url": "https://element.io/cookie-policy",
     "map_style_url": "https://api.maptiler.com/maps/streets/style.json?key=fU3vlMsMn4Jb6dnEIFsx",
     "setting_defaults": {
-        "RustCrypto.staged_rollout_percent": 10
+        "RustCrypto.staged_rollout_percent": 30
     }
 }


### PR DESCRIPTION
We've not heard any concerns recently, and the [last blocker](https://github.com/element-hq/element-web/issues/27324) was released on 23 April. Let's migrate 30% of existing users in the next Element Desktop release.

Part of https://github.com/element-hq/element-web/issues/27284