### PR TITLE
Fix deploy running even if a packaging stage fails

### DIFF
--- a/.github/workflows/build_and_deploy.yaml
+++ b/.github/workflows/build_and_deploy.yaml
@@ -104,7 +104,7 @@ jobs:
             - windows
         runs-on: ubuntu-latest
         name: ${{ needs.prepare.outputs.deploy == 'true' && 'Deploy' || 'Deploy (dry-run)' }}
-        if: always() && !failure() && !cancelled()
+        if: always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
         environment: ${{ needs.prepare.outputs.deploy == 'true' && 'packages.element.io' || '' }}
         steps:
             - name: Download artifacts


### PR DESCRIPTION
`failure()` is only true if a previous `step` has failed, no steps in this job have yet ran at time of evaluation, not a very helpful expression seemingly.