### PR TITLE
fix: window focus on notification click

### DIFF
--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -98,9 +98,8 @@ ipcMain.on("ipcCall", async function (_ev: IpcMainEvent, payload) {
         case "focusWindow":
             if (global.mainWindow.isMinimized()) {
                 global.mainWindow.restore();
-            } else if (!global.mainWindow.isVisible()) {
-                global.mainWindow.show();
             } else {
+                global.mainWindow.show();
                 global.mainWindow.focus();
             }
             break;


### PR DESCRIPTION
This was an attempt to fix #1054/#790, which I experienced on macOS, but this *isn't working* - I could use guidance on where the issue could be.

Element's desktop notifications, on Mac, don't bring the window to the foreground when clicked. Element *does* switch to the appropriate chat if that chat wasn't the active session, but the window still remains behind whatever other windows are in front of it and keyboard focus remains with the active window.

When looking at the notification code, I did see that the "loudNotification" focus handler was set to only be active on Windows. I tried updating this to also check for Darwin, and to add an explicit `global.mainWindow.show();` call, but neither seemed to have any effect. Any other suggestions as to where I could look to possibly fix this?

## Checklist

-   [x] Ensure your code works with manual testing.
-   [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [x] Linter and other CI checks pass.
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/vector-im/element-desktop/blob/develop/CONTRIBUTING.md)).

Fixes #1054.
Fixes #790.