### PR TITLE
Fix contributing link in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,4 +5,4 @@
 -   [ ] Ensure your code works with manual testing.
 -   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
 -   [ ] Linter and other CI checks pass.
--   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/vector-im/element-desktop/blob/develop/CONTRIBUTING.md)).
+-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/vector-im/element-web/blob/develop/CONTRIBUTING.md)).


### PR DESCRIPTION
Element-desktop doesn't have its own CONTRIBUTING, which is probably a problem in itself, but this is an easier fix
