### PR TITLE
Enable flashFrame usage on linux

### DIFF
--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -38,13 +38,15 @@ ipcMain.on("setBadgeCount", function (_ev: IpcMainEvent, count: number): void {
 
 let focusHandlerAttached = false;
 ipcMain.on("loudNotification", function (): void {
-    if (process.platform === "win32" && global.mainWindow && !global.mainWindow.isFocused() && !focusHandlerAttached) {
-        global.mainWindow.flashFrame(true);
-        global.mainWindow.once("focus", () => {
-            global.mainWindow?.flashFrame(false);
-            focusHandlerAttached = false;
-        });
-        focusHandlerAttached = true;
+    if (process.platform === "win32" || process.platform === "linux") {
+        if (global.mainWindow && !global.mainWindow.isFocused() && !focusHandlerAttached) {
+            global.mainWindow.flashFrame(true);
+            global.mainWindow.once("focus", () => {
+                global.mainWindow?.flashFrame(false);
+                focusHandlerAttached = false;
+            });
+            focusHandlerAttached = true;
+        }
     }
 });
 


### PR DESCRIPTION
Update the function that calls flashFrame when receiving a "Loud" notification so that it will execute on linux, as well as windows. This will flash the window to attract user's attention when there are new unread messages until the window is focused again. This will bring parity for behavior between the Windows and Linux desktop apps.

Fixes: #715
Type: defect

## Checklist

-   [x] Ensure your code works with manual testing.
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [x] Linter and other CI checks pass.
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/vector-im/element-web/blob/develop/CONTRIBUTING.md)).
