### PR TITLE
Roll out Rust crypto to 60% of existing users of stable Element Desktop

### DIFF
--- a/element.io/release/config.json
+++ b/element.io/release/config.json
@@ -46,6 +46,6 @@
     "privacy_policy_url": "https://element.io/cookie-policy",
     "map_style_url": "https://api.maptiler.com/maps/streets/style.json?key=fU3vlMsMn4Jb6dnEIFsx",
     "setting_defaults": {
-        "RustCrypto.staged_rollout_percent": 30
+        "RustCrypto.staged_rollout_percent": 60
     }
 }


### PR DESCRIPTION
It's time to roll out Rust crypto a bit further. Let's migrate the next 30% of existing users in the next Element Desktop release, taking us to 60% of existing users.

Followup to https://github.com/element-hq/element-desktop/pull/1650. Part of https://github.com/element-hq/element-web/issues/27490.