### PR TITLE
Tighten macOS entitlements

### DIFF
--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -9,11 +9,11 @@
          Latest electron-builder does, but it appears to be causing issues:
          (https://github.com/electron-userland/electron-builder/issues/4390)
     -->
+
     <!-- https://github.com/electron/electron-notarize#prerequisites -->
     <key>com.apple.security.cs.allow-jit</key>
     <true/>
-    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-    <true/>
+
     <!-- https://github.com/electron-userland/electron-builder/issues/3940 -->
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>


### PR DESCRIPTION
Electron 12+ do not require allow-unsigned-executable-memory