### PR TITLE
remove Libera.Chat bridge from room_directory

### DIFF
--- a/element.io/nightly/config.json
+++ b/element.io/nightly/config.json
@@ -23,7 +23,7 @@
     "uisi_autorageshake_app": "element-auto-uisi",
     "show_labs_settings": true,
     "room_directory": {
-        "servers": ["matrix.org", "gitter.im", "libera.chat"]
+        "servers": ["matrix.org", "gitter.im"]
     },
     "enable_presence_by_hs_url": {
         "https://matrix.org": false,

--- a/element.io/release/config.json
+++ b/element.io/release/config.json
@@ -22,7 +22,7 @@
     "bug_report_endpoint_url": "https://element.io/bugreports/submit",
     "uisi_autorageshake_app": "element-auto-uisi",
     "room_directory": {
-        "servers": ["matrix.org", "gitter.im", "libera.chat"]
+        "servers": ["matrix.org", "gitter.im"]
     },
     "show_labs_settings": false,
     "enable_presence_by_hs_url": {


### PR DESCRIPTION
As of 2023-08-05, the official Libera.Chat bridge was taken down.
