### PR TITLE
Remove glob workaround

### DIFF
--- a/src/@types/glob.d.ts
+++ b/src/@types/glob.d.ts
@@ -1,6 +1,0 @@
-import { GlobOptions } from "glob";
-
-declare module "glob" {
-    // Workaround for @electron/asar importing IOptions instead of GlobOptions
-    export type IOptions = GlobOptions;
-}


### PR DESCRIPTION
It seems to be no longer necessary as of https://github.com/electron/asar/compare/v3.2.3...v3.2.4