### PR TITLE
Fix inability to click on non-logged-in modals on macOS

### DIFF
--- a/src/macos-titlebar.ts
+++ b/src/macos-titlebar.ts
@@ -93,7 +93,8 @@ export function setupMacosTitleBar(window: BrowserWindow): void {
             .mx_LeftPanel,
             .mx_RoomView,
             .mx_SpaceRoomView,
-            .mx_AccessibleButton {
+            .mx_AccessibleButton,
+            .mx_Dialog {
                 -webkit-app-region: no-drag;
             }
             /* Exclude context menus and their backgrounds */


### PR DESCRIPTION
Fixes https://github.com/element-hq/element-desktop/issues/1994