### PR TITLE
Roll back electron to fix context-menu on macOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
         "app-builder-lib": "25.1.8",
         "chokidar": "^4.0.0",
         "detect-libc": "^2.0.0",
-        "electron": "^33.0.0",
+        "electron": "32.0.0",
         "electron-builder": "25.1.8",
         "electron-builder-squirrel-windows": "25.1.8",
         "electron-devtools-installer": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3619,10 +3619,10 @@ electron-window-state@^5.0.3:
     jsonfile "^4.0.0"
     mkdirp "^0.5.1"
 
-electron@^33.0.0:
-  version "33.3.1"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-33.3.1.tgz#26d63b3a110c4a9db639c33633bf806f91b4f649"
-  integrity sha512-Z7l2bVgpdKxHQMI4i0CirBX2n+iCYKOx5mbzNM3BpOyFELwlobEXKmzCmEnwP+3EcNeIhUQyIEBFQxN06QgdIw==
+electron@32.0.0:
+  version "32.0.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-32.0.0.tgz#ccb1334d7f1f1a5387ad8f16a06180053ea9278a"
+  integrity sha512-rs+VkhztJd2LvRX7d3ikKH+EIHMW4vKM2l5qp7Dx/dLQAKKz3IFNKyYhYzczDnqO+/jUvx0ic0SQvqpv1/ZAsw==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^20.9.0"


### PR DESCRIPTION
Can be undone once https://github.com/electron/electron/pull/44978 is backported to v33 or v34 goes stable.

Fixes https://github.com/element-hq/element-desktop/issues/2073

Does not affect RC
