### PR TITLE
Fix: If two images are posted within the same second, only the first one will be saved.

### DIFF
--- a/src/webcontents-handler.ts
+++ b/src/webcontents-handler.ts
@@ -141,13 +141,17 @@ function onLinkContextMenu(ev: Event, params: ContextMenuParams, webContents: We
                 label: _t("right_click_menu|save_image_as"),
                 accelerator: "s",
                 async click(): Promise<void> {
-                    const targetFileName = params.suggestedFilename || params.altText || "image.png";
+                    const originalFileName = params.suggestedFilename || params.altText || "image.png";
+                    const timestamp = Date.now(); // Get current time in milliseconds
+                    const ext = path.extname(originalFileName);
+                    const baseName = path.basename(originalFileName, ext);
+                    const targetFileName = `${baseName}-${timestamp}${ext}`;
                     const { filePath } = await dialog.showSaveDialog({
                         defaultPath: targetFileName,
                     });
-
+    
                     if (!filePath) return; // user cancelled dialog
-
+    
                     try {
                         if (url.startsWith("data:")) {
                             await writeNativeImage(filePath, nativeImage.createFromDataURL(url));


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [x] Ensure your code works with manual testing.
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-desktop)

### My approach to solve the issue:
Added a timestamp to the filename:
Used Date.now() to get the current time in milliseconds.
Modified the targetFileName to include the timestamp, ensuring uniqueness.
Closes element-hq/element-web#29079 
