### PR TITLE
Deprecate ia32 Windows builds

### DIFF
--- a/.github/workflows/build_and_deploy.yaml
+++ b/.github/workflows/build_and_deploy.yaml
@@ -63,18 +63,10 @@ jobs:
         strategy:
             matrix:
                 arch: [ia32, x64, arm64]
-                include:
-                    - arch: ia32
-                      extra_config: |-
-                        "user_notice": {
-                            "title": "Element will no longer be available for this platform soon",
-                            "description": "Support for 32-bit Windows installations will be removed in the next release."
-                        }
         uses: ./.github/workflows/build_windows.yaml
         secrets: inherit
         with:
             sign: true
-            extra_config: ${{ matrix.extra_config }}
             arch: ${{ matrix.arch }}
             version: ${{ needs.prepare.outputs.nightly-version }}
 

--- a/.github/workflows/build_and_deploy.yaml
+++ b/.github/workflows/build_and_deploy.yaml
@@ -63,10 +63,18 @@ jobs:
         strategy:
             matrix:
                 arch: [ia32, x64, arm64]
+                include:
+                    - arch: ia32
+                      extra_config: |-
+                        "user_notice": {
+                            "title": "Element will no longer be available for this platform soon",
+                            "description": "Support for 32-bit Windows installations will be removed in the next release."
+                        }
         uses: ./.github/workflows/build_windows.yaml
         secrets: inherit
         with:
             sign: true
+            extra_config: ${{ matrix.extra_config }}
             arch: ${{ matrix.arch }}
             version: ${{ needs.prepare.outputs.nightly-version }}
 

--- a/.github/workflows/build_windows.yaml
+++ b/.github/workflows/build_windows.yaml
@@ -119,8 +119,8 @@ jobs:
                 mv config.json old-config.json
                 echo ${{ inputs.extra_config }} | jq -s '.[0] * .[1]' old-config.json - > config.json
                 rm old-config.json
-                rm webapp.asar
                 cd ..
+                rm webapp.asar
                 yarn asar pack config-edit/ webpack.asar
 
             - name: Set up sqlcipher macros

--- a/.github/workflows/build_windows.yaml
+++ b/.github/workflows/build_windows.yaml
@@ -22,6 +22,10 @@ on:
                 type: string
                 required: true
                 description: "The architecture to build for, one of 'x64' | 'ia32' | 'arm64'"
+            extra_config:
+                type: string
+                required: false
+                description: "Additional configuration for config.json to be inserted for this build."
             version:
                 type: string
                 required: false
@@ -104,6 +108,20 @@ jobs:
 
             - name: Install Deps
               run: "yarn install --frozen-lockfile"
+
+            - name: Insert config snippet
+              if: inputs.extra_config != ''
+              shell: bash
+              run: |
+                mkdir config-edit
+                yarn asar extract webapp.asar config-edit
+                cd config-edit
+                mv config.json old-config.json
+                echo ${{ inputs.extra_config }} | jq -s '.[0] * .[1]' old-config.json - > config.json
+                rm old-config.json
+                rm webapp.asar
+                cd ..
+                yarn asar pack config-edit/ webpack.asar
 
             - name: Set up sqlcipher macros
               if: steps.cache.outputs.cache-hit != 'true' && contains(inputs.arch, 'arm')

--- a/.github/workflows/build_windows.yaml
+++ b/.github/workflows/build_windows.yaml
@@ -57,7 +57,7 @@ jobs:
                           "target": "i686-pc-windows-msvc",
                           "build-args": "--ia32",
                           "arch": "x86",
-                          "extra_config": "{\"user_notice\": {\"title\": \"Element will no longer be available for this platform soon\",\"description\": \"Support for 32-bit Windows installations will be removed in the next release.\"}}"
+                          "extra_config": "{\"user_notice\": {\"title\": \"Your desktop support ends soon\",\"description\": \"Support for 32-bit Windows installations will end soon, this impacts you. Transition to the web or mobile app for continued access.\"}}"
                         }
                       }
 

--- a/.github/workflows/build_windows.yaml
+++ b/.github/workflows/build_windows.yaml
@@ -67,6 +67,21 @@ jobs:
               with:
                   name: webapp
 
+            - name: Insert config snippet
+              if: steps.config.outputs.extra_config != ''
+              shell: bash
+              run: |
+                mkdir config-edit
+                yarn asar extract webapp.asar config-edit
+                cd config-edit
+                mv config.json old-config.json
+                echo '${{ steps.config.outputs.extra_config }}' | jq -s '.[0] * .[1]' old-config.json - > config.json
+                rm old-config.json
+                cd ..
+                rm webapp.asar
+                yarn asar pack config-edit/ webpack.asar
+
+
             - name: Cache .hak
               id: cache
               uses: actions/cache@v4
@@ -105,20 +120,6 @@ jobs:
 
             - name: Install Deps
               run: "yarn install --frozen-lockfile"
-
-            - name: Insert config snippet
-              if: steps.config.outputs.extra_config != ''
-              shell: bash
-              run: |
-                mkdir config-edit
-                yarn asar extract webapp.asar config-edit
-                cd config-edit
-                mv config.json old-config.json
-                echo ${{ steps.config.outputs.extra_config }} | jq -s '.[0] * .[1]' old-config.json - > config.json
-                rm old-config.json
-                cd ..
-                rm webapp.asar
-                yarn asar pack config-edit/ webpack.asar
 
             - name: Set up sqlcipher macros
               if: steps.cache.outputs.cache-hit != 'true' && contains(inputs.arch, 'arm')

--- a/.github/workflows/build_windows.yaml
+++ b/.github/workflows/build_windows.yaml
@@ -58,9 +58,10 @@ jobs:
                           "build-args": "--ia32",
                           "arch": "x86",
                           "extra_config": "{
-                            \"user_notice\": {
-                              \"title\": \"Element will no longer be available for this platform soon\",
-                              \"description\": \"Support for 32-bit Windows installations will be removed in the next release.\"
+                              \"user_notice\": {
+                                \"title\": \"Element will no longer be available for this platform soon\",
+                                \"description\": \"Support for 32-bit Windows installations will be removed in the next release.\"
+                              }
                             }"
                           }
                         }

--- a/.github/workflows/build_windows.yaml
+++ b/.github/workflows/build_windows.yaml
@@ -60,7 +60,11 @@ jobs:
                         "ia32": {
                           "target": "i686-pc-windows-msvc",
                           "build-args": "--ia32",
-                          "arch": "x86"
+                          "arch": "x86",
+                          "extra_config": {
+                            "title": "Element will no longer be available for this platform soon",
+                            "description": "Support for 32-bit Windows installations will be removed in the next release."
+                          }
                         }
                       }
 
@@ -110,14 +114,14 @@ jobs:
               run: "yarn install --frozen-lockfile"
 
             - name: Insert config snippet
-              if: inputs.extra_config != ''
+              if: steps.config.outputs.extra_config != ''
               shell: bash
               run: |
                 mkdir config-edit
                 yarn asar extract webapp.asar config-edit
                 cd config-edit
                 mv config.json old-config.json
-                echo ${{ inputs.extra_config }} | jq -s '.[0] * .[1]' old-config.json - > config.json
+                echo ${{ steps.config.outputs.extra_config }} | jq -s '.[0] * .[1]' old-config.json - > config.json
                 rm old-config.json
                 cd ..
                 rm webapp.asar

--- a/.github/workflows/build_windows.yaml
+++ b/.github/workflows/build_windows.yaml
@@ -57,12 +57,7 @@ jobs:
                           "target": "i686-pc-windows-msvc",
                           "build-args": "--ia32",
                           "arch": "x86",
-                          "extra_config": "{
-                              \"user_notice\": {
-                                \"title\": \"Element will no longer be available for this platform soon\",
-                                \"description\": \"Support for 32-bit Windows installations will be removed in the next release.\"
-                              }
-                            }"
+                          "extra_config": "{\"user_notice\": {\"title\": \"Element will no longer be available for this platform soon\",\"description\": \"Support for 32-bit Windows installations will be removed in the next release.\"}}"
                           }
                         }
                       }

--- a/.github/workflows/build_windows.yaml
+++ b/.github/workflows/build_windows.yaml
@@ -67,21 +67,6 @@ jobs:
               with:
                   name: webapp
 
-            - name: Insert config snippet
-              if: steps.config.outputs.extra_config != ''
-              shell: bash
-              run: |
-                mkdir config-edit
-                yarn asar extract webapp.asar config-edit
-                cd config-edit
-                mv config.json old-config.json
-                echo '${{ steps.config.outputs.extra_config }}' | jq -s '.[0] * .[1]' old-config.json - > config.json
-                rm old-config.json
-                cd ..
-                rm webapp.asar
-                yarn asar pack config-edit/ webpack.asar
-
-
             - name: Cache .hak
               id: cache
               uses: actions/cache@v4
@@ -120,6 +105,21 @@ jobs:
 
             - name: Install Deps
               run: "yarn install --frozen-lockfile"
+
+            - name: Insert config snippet
+              if: steps.config.outputs.extra_config != ''
+              shell: bash
+              run: |
+                mkdir config-edit
+                yarn asar extract webapp.asar config-edit
+                cd config-edit
+                mv config.json old-config.json
+                echo '${{ steps.config.outputs.extra_config }}' | jq -s '.[0] * .[1]' old-config.json - > config.json
+                rm old-config.json
+                cd ..
+                rm webapp.asar
+                yarn asar pack config-edit/ webpack.asar
+
 
             - name: Set up sqlcipher macros
               if: steps.cache.outputs.cache-hit != 'true' && contains(inputs.arch, 'arm')

--- a/.github/workflows/build_windows.yaml
+++ b/.github/workflows/build_windows.yaml
@@ -58,7 +58,6 @@ jobs:
                           "build-args": "--ia32",
                           "arch": "x86",
                           "extra_config": "{\"user_notice\": {\"title\": \"Element will no longer be available for this platform soon\",\"description\": \"Support for 32-bit Windows installations will be removed in the next release.\"}}"
-                          }
                         }
                       }
 

--- a/.github/workflows/build_windows.yaml
+++ b/.github/workflows/build_windows.yaml
@@ -22,10 +22,6 @@ on:
                 type: string
                 required: true
                 description: "The architecture to build for, one of 'x64' | 'ia32' | 'arm64'"
-            extra_config:
-                type: string
-                required: false
-                description: "Additional configuration for config.json to be inserted for this build."
             version:
                 type: string
                 required: false
@@ -62,8 +58,10 @@ jobs:
                           "build-args": "--ia32",
                           "arch": "x86",
                           "extra_config": {
-                            "title": "Element will no longer be available for this platform soon",
-                            "description": "Support for 32-bit Windows installations will be removed in the next release."
+                            "user_notice": {
+                              "title": "Element will no longer be available for this platform soon",
+                              "description": "Support for 32-bit Windows installations will be removed in the next release."
+                            }
                           }
                         }
                       }

--- a/.github/workflows/build_windows.yaml
+++ b/.github/workflows/build_windows.yaml
@@ -118,7 +118,7 @@ jobs:
                   rm old-config.json
                   cd ..
                   rm webapp.asar
-                  yarn asar pack config-edit/ webpack.asar
+                  yarn asar pack config-edit/ webapp.asar
 
             - name: Set up sqlcipher macros
               if: steps.cache.outputs.cache-hit != 'true' && contains(inputs.arch, 'arm')

--- a/.github/workflows/build_windows.yaml
+++ b/.github/workflows/build_windows.yaml
@@ -110,16 +110,15 @@ jobs:
               if: steps.config.outputs.extra_config != ''
               shell: bash
               run: |
-                mkdir config-edit
-                yarn asar extract webapp.asar config-edit
-                cd config-edit
-                mv config.json old-config.json
-                echo '${{ steps.config.outputs.extra_config }}' | jq -s '.[0] * .[1]' old-config.json - > config.json
-                rm old-config.json
-                cd ..
-                rm webapp.asar
-                yarn asar pack config-edit/ webpack.asar
-
+                  mkdir config-edit
+                  yarn asar extract webapp.asar config-edit
+                  cd config-edit
+                  mv config.json old-config.json
+                  echo '${{ steps.config.outputs.extra_config }}' | jq -s '.[0] * .[1]' old-config.json - > config.json
+                  rm old-config.json
+                  cd ..
+                  rm webapp.asar
+                  yarn asar pack config-edit/ webpack.asar
 
             - name: Set up sqlcipher macros
               if: steps.cache.outputs.cache-hit != 'true' && contains(inputs.arch, 'arm')

--- a/.github/workflows/build_windows.yaml
+++ b/.github/workflows/build_windows.yaml
@@ -57,11 +57,11 @@ jobs:
                           "target": "i686-pc-windows-msvc",
                           "build-args": "--ia32",
                           "arch": "x86",
-                          "extra_config": {
-                            "user_notice": {
-                              "title": "Element will no longer be available for this platform soon",
-                              "description": "Support for 32-bit Windows installations will be removed in the next release."
-                            }
+                          "extra_config": "{
+                            \"user_notice\": {
+                              \"title\": \"Element will no longer be available for this platform soon\",
+                              \"description\": \"Support for 32-bit Windows installations will be removed in the next release.\"
+                            }"
                           }
                         }
                       }


### PR DESCRIPTION
This PR inserts a code snippet to mark the deprecation of 32 bit windows releases, the first part of https://github.com/element-hq/element-desktop/issues/1666

![image](https://github.com/user-attachments/assets/d6a9d1ed-474d-4d5e-993b-715ad1ac29df)



## Checklist

- [ ] Ensure your code works with manual testing.
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-desktop)
