### PR TITLE
Support specifying the profile dir path via env var (#2226)

### DIFF
--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -43,12 +43,12 @@ const argv = minimist(process.argv, {
 
 if (argv["help"]) {
     console.log("Options:");
-    console.log(
-        "  --profile-dir {path}: Path to where to store the profile. May also be specified via the ELEMENT_PROFILE_DIR environment variable.",
-    );
+    console.log("  --profile-dir {path}: Path to where to store the profile.");
     console.log(
         `  --profile {name}:     Name of alternate profile to use, allows for running multiple accounts.\n` +
-            `                         Ignored if --profile-dir is specified, can be combined with ELEMENT_PROFILE_DIR environment variable.`,
+            `                         Ignored if --profile-dir is specified.\n` +
+            `                         The ELEMENT_PROFILE_DIR environment variable may be used to change the default profile path.\n` +
+            `                         It is overridden by --profile-dir, but can be combined with --profile.`,
     );
     console.log("  --devtools:           Install and use react-devtools and react-perf.");
     console.log(

--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -75,7 +75,7 @@ if (userDataPathInProtocol) {
 } else if (argv["profile-dir"]) {
     userDataPath = argv["profile-dir"];
 } else {
-    let newUserDataPath = app.getPath("userData");
+    let newUserDataPath = process.env.ELEMENT_PROFILE_DIR ?? app.getPath("userData");
     if (argv["profile"]) {
         newUserDataPath += "-" + argv["profile"];
     }

--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -46,7 +46,10 @@ if (argv["help"]) {
     console.log(
         "  --profile-dir {path}: Path to where to store the profile. May also be specified via the ELEMENT_PROFILE_DIR environment variable.",
     );
-    console.log("  --profile {name}:     Name of alternate profile to use, allows for running multiple accounts.");
+    console.log(
+        `  --profile {name}:     Name of alternate profile to use, allows for running multiple accounts.\n` +
+            `                         Ignored if --profile-dir is specified, can be combined with ELEMENT_PROFILE_DIR environment variable.`,
+    );
     console.log("  --devtools:           Install and use react-devtools and react-perf.");
     console.log(
         `  --config:             Path to the config.json file. May also be specified via the ELEMENT_DESKTOP_CONFIG_JSON environment variable.\n` +

--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -43,7 +43,9 @@ const argv = minimist(process.argv, {
 
 if (argv["help"]) {
     console.log("Options:");
-    console.log("  --profile-dir {path}: Path to where to store the profile.");
+    console.log(
+        "  --profile-dir {path}: Path to where to store the profile. May also be specified via the ELEMENT_PROFILE_DIR environment variable.",
+    );
     console.log("  --profile {name}:     Name of alternate profile to use, allows for running multiple accounts.");
     console.log("  --devtools:           Install and use react-devtools and react-perf.");
     console.log(


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Implements #2226 without variable expansion.
I tried to implement a playwright test although that eventually passed it is relatively complex because `--profile-dir` is used to set `tmpDir`. Let me know if that is desired anyways or if additional checks for the supplied path or any documentation is required.

## Checklist

- [x] Ensure your code works with manual testing.
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-desktop)
