### PR TITLE
Silence message search syntax error pop-up

### DIFF
--- a/src/seshat.ts
+++ b/src/seshat.ts
@@ -196,7 +196,8 @@ ipcMain.on("seshat", async function (_ev: IpcMainEvent, payload): Promise<void> 
             try {
                 ret = await eventIndex?.search(args[0]);
             } catch (e) {
-                sendError(payload.id, <Error>e);
+                // Do not call sendError to avoid havin a pop-up while typing fancy seshat search syntaxes
+                console.log(<Error>e);
                 return;
             }
             break;


### PR DESCRIPTION
I sometimes use `tantivy`'s search syntaxes in the message search: https://docs.rs/tantivy/0.12.0/tantivy/query/struct.QueryParser.html

The problem is that message search queries are sent to `tantivy` while typing them, thus an error pop-up can appear while typing the search request if the syntax is invalid.

The screen below is an example of what happens when I type `"term1` in the message search, when I am actually trying to type `"term1 term2"` but the pop-up appeared too quick for me to finish writing:

![search_error](https://github.com/user-attachments/assets/5ac5b246-1a5a-4de6-853a-8f79ed1e8668)

This PR aims to silence this pop and instead log the error in the console to not interrupt the user while he is typing.