### PR TITLE
Notification fixes for Windows - AppID name was messing up handler

### DIFF
--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -600,4 +600,4 @@ app.on("second-instance", (ev, commandLine, workingDirectory) => {
 // installer uses for the shortcut icon.
 // This makes notifications work on windows 8.1 (and is
 // a noop on other platforms).
-app.setAppUserModelId("com.squirrel.element-desktop.Element");
+app.setAppUserModelId("com.squirrel.element.desktop");

--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -596,8 +596,9 @@ app.on("second-instance", (ev, commandLine, workingDirectory) => {
     }
 });
 
-// Set the App User Model ID to match what the squirrel
-// installer uses for the shortcut icon.
-// This makes notifications work on windows 8.1 (and is
-// a noop on other platforms).
+// This is required to make notification handlers work
+// on Windows 8.1/10/11 (and is a noop on other platforms);
+// It must also match the ID found in 'electron-builder'
+// in order to get the title and icon to show up correctly.
+// Ref: https://stackoverflow.com/a/77314604/3525780
 app.setAppUserModelId("im.riot.app");

--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -600,4 +600,4 @@ app.on("second-instance", (ev, commandLine, workingDirectory) => {
 // installer uses for the shortcut icon.
 // This makes notifications work on windows 8.1 (and is
 // a noop on other platforms).
-app.setAppUserModelId("com.squirrel.element.desktop");
+app.setAppUserModelId("im.riot.app");


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Closes #770  🚀

For some reason ~the dash in~ `com.squirrel.element-desktop.Element` was causing trouble when notifications were handled, so much so that Electron wasn't even receiving the "focusWindow" event from the IPC handler. It was being triggered, but not received. I came to this conclusion after building both web and desktop, making both talk together, and messing around with the handlers. I'm embarassed to say how much hours that took... Anyway...

~With the dash removed~, the event is now being received sucessfully and **clicking on the notificaiton works again**.
As a further change, the bundle name was also changed to `im.riot.app` to match the electron bundle config, so the notification gets a proper icon and title.

As a cautionary measure, I have also built the app as an MSI package to properly install and test it, and it works fine.

**EDIT 18.04.25:** I looked at the bug again since I thought it was odd that a dash messes up notifications, and I discovered that **it isn't the dash** that messes them up. Looks like ANY other name works, but as soon as  `com.squirrel.element-desktop.Element` is entered, the notification breaks, for whatever reason. It's not the uppercase letter either - add any letter and it starts to work again. Very odd. I will continue to investigate, but the PR could technically be merged, as the app ID is just responsible for Windows notificatations anyways, as per:
```
// This makes notifications work on windows 8.1 (and is a noop on other platforms).
```
My best guess is that it clashes with the installer name, as per:
```
// Set the App User Model ID to match what the squirrel installer uses for the shortcut icon.
```

## Checklist

- [x] Ensure your code works with manual testing.
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-desktop)
