### PR TITLE
Revert "Update dependency electron to v36"

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
         "app-builder-lib": "26.0.12",
         "chokidar": "^4.0.0",
         "detect-libc": "^2.0.0",
-        "electron": "36.0.0",
+        "electron": "35.2.0",
         "electron-builder": "26.0.12",
         "electron-builder-squirrel-windows": "26.0.12",
         "electron-devtools-installer": "^4.0.0",
@@ -117,7 +117,6 @@
     },
     "resolutions": {
         "@types/node": "18.19.87",
-        "config-file-ts": "0.2.8-rc1",
-        "node-abi": "4.4.0"
+        "config-file-ts": "0.2.8-rc1"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3558,10 +3558,10 @@ electron-winstaller@5.4.0:
   optionalDependencies:
     "@electron/windows-sign" "^1.1.2"
 
-electron@36.0.0:
-  version "36.0.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-36.0.0.tgz#ffbe7ca9edecaee53617f29a088be10bbed9a45f"
-  integrity sha512-MhBL5tgzqLsiw++YXxzXRvF5s90gelcEZP4Upz/aaRmmoscmCw/EtimxMSH6EPnKt+8KwBY9RVAdlcffFPYkyw==
+electron@35.2.0:
+  version "35.2.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-35.2.0.tgz#4701f455a2bc41c992cc529b42203c530223dcd8"
+  integrity sha512-GHda7oCkN0pA23qzah735DEbRa06IPwlzP3uvjAmf9af8gxdj5i93JEHeQVGVmSVpd7sSb1pfecs9nz7B1q5ag==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^22.7.7"
@@ -5650,12 +5650,12 @@ negotiator@^1.0.0:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-1.0.0.tgz#b6c91bb47172d69f93cfd7c357bbb529019b5f6a"
   integrity sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==
 
-node-abi@4.4.0, node-abi@^3.3.0, node-abi@^3.45.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-4.4.0.tgz#f17a2880a556337030a02b7f92e308946cdbbfc9"
-  integrity sha512-+sBEWs/HZ3ZDBtPSPKfYndkTF9ebr1BJm/z2TBDJj/upiOx9J6BeGXRtFyOXz1r6vUqzsCRM5pUr+K83i64agg==
+node-abi@^3.3.0, node-abi@^3.45.0:
+  version "3.74.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.74.0.tgz#5bfb4424264eaeb91432d2adb9da23c63a301ed0"
+  integrity sha512-c5XK0MjkGBrQPGYG24GBADZud0NCbznxNx0ZkS+ebUTrmV1qTDxPxSL8zEAPURXSbLRWVexxmP4986BziahL5w==
   dependencies:
-    semver "^7.6.3"
+    semver "^7.3.5"
 
 node-addon-api@^1.6.3:
   version "1.7.2"


### PR DESCRIPTION
Reverts element-hq/element-desktop#2293

Due to https://github.com/electron/electron/issues/46538

Another option would be to add the flag mentioned in that issue to force gtk3, but this seems more likely to break something else. I'm assuming this will be fixed in electron upstream before too long, so I suggest downgrade for now.