### PR TITLE
Apply workaround to fix app launching on Linux

### DIFF
--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -298,6 +298,11 @@ app.commandLine.appendSwitch("--enable-usermedia-screen-capturing");
 if (!app.commandLine.hasSwitch("enable-features")) {
     app.commandLine.appendSwitch("enable-features", "WebRTCPipeWireCapturer");
 }
+// Workaround bug in electron 36:https://github.com/electron/electron/issues/46538
+// Hopefully this will no longer be needed soon and can be removed
+if (process.platform === "linux") {
+    app.commandLine.appendSwitch('gtk-version', '3');
+}
 
 const gotLock = app.requestSingleInstanceLock();
 if (!gotLock) {


### PR DESCRIPTION
Fixes https://github.com/element-hq/element-desktop/issues/2297 by applying the workaround to force gtk 3, which by all accounts should be safer than was imagining it might be.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Ensure your code works with manual testing.
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-desktop)
