### PR TITLE
Wire up setContentProtectionEnable for Windows & macOS

### DIFF
--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -485,6 +485,8 @@ app.on("ready", async () => {
         },
     });
 
+    global.mainWindow.setContentProtection(store.get("enableContentProtection"));
+
     try {
         console.debug("Ensuring storage is ready");
         if (!(await store.prepareSafeStorage(global.mainWindow.webContents.session))) return;

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -69,18 +69,6 @@ ipcMain.on("ipcCall", async function (_ev: IpcMainEvent, payload) {
         case "getUpdateFeedUrl":
             ret = autoUpdater.getFeedURL();
             break;
-        case "getSettingValue": {
-            const [settingName] = args;
-            const setting = Settings[settingName];
-            ret = await setting.read();
-            break;
-        }
-        case "setSettingValue": {
-            const [settingName, value] = args;
-            const setting = Settings[settingName];
-            await setting.write(value);
-            break;
-        }
         case "setLanguage":
             global.appLocalization.setAppLocale(args[0]);
             break;

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -9,7 +9,6 @@ import { app, autoUpdater, desktopCapturer, ipcMain, powerSaveBlocker, TouchBar,
 
 import IpcMainEvent = Electron.IpcMainEvent;
 import { randomArray } from "./utils.js";
-import { Settings } from "./settings.js";
 import { getDisplayMediaCallback, setDisplayMediaCallback } from "./displayMediaCallback.js";
 import Store, { clearDataAndRelaunch } from "./store.js";
 

--- a/src/preload.cts
+++ b/src/preload.cts
@@ -54,11 +54,20 @@ contextBridge.exposeInMainWorld("electron", {
         protocol: string;
         sessionId: string;
         config: IConfigOptions;
+        supportedSettings: Record<string, boolean>;
     }> {
-        const [{ protocol, sessionId }, config] = await Promise.all([
+        const [{ protocol, sessionId }, config, supportedSettings] = await Promise.all([
             ipcRenderer.invoke("getProtocol"),
             ipcRenderer.invoke("getConfig"),
+            ipcRenderer.invoke("getSupportedSettings"),
         ]);
-        return { protocol, sessionId, config };
+        return { protocol, sessionId, config, supportedSettings };
+    },
+
+    async setSettingValue(settingName: string, value: any): Promise<void> {
+        return ipcRenderer.invoke("setSettingValue", settingName, value);
+    },
+    async getSettingValue(settingName: string): Promise<any> {
+        return ipcRenderer.invoke("getSettingValue", settingName);
     },
 });

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -79,8 +79,9 @@ const Settings: Record<string, Setting> = {
     },
     "Electron.enableContentProtection": {
         // Unsupported on Linux https://www.electronjs.org/docs/latest/api/browser-window#winsetcontentprotectionenable-macos-windows
+        // Broken on macOS https://github.com/electron/electron/issues/19880
         supported(): boolean {
-            return process.platform !== "linux";
+            return process.platform === "win32";
         },
         async read(): Promise<any> {
             return Store.instance?.get("enableContentProtection");
@@ -104,6 +105,7 @@ ipcMain.handle("setSettingValue", async (_ev, settingName: string, value: any) =
     if (!setting) {
         throw new Error(`Unknown setting: ${settingName}`);
     }
+    console.debug(`Writing setting value for: ${settingName} = ${value}`);
     await setting.write(value);
 });
 ipcMain.handle("getSettingValue", async (_ev, settingName: string) => {
@@ -111,5 +113,7 @@ ipcMain.handle("getSettingValue", async (_ev, settingName: string) => {
     if (!setting) {
         throw new Error(`Unknown setting: ${settingName}`);
     }
-    return await setting.read();
+    const value = await setting.read();
+    console.debug(`Reading setting value for: ${settingName} = ${value}`);
+    return value;
 });

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -5,12 +5,15 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { ipcMain } from "electron";
+
 import * as tray from "./tray.js";
 import Store from "./store.js";
 
 interface Setting {
     read(): Promise<any>;
     write(value: any): Promise<void>;
+    supported?(): boolean;
 }
 
 export const Settings: Record<string, Setting> = {
@@ -35,7 +38,10 @@ export const Settings: Record<string, Setting> = {
         },
     },
     "Electron.alwaysShowMenuBar": {
-        // not supported on macOS
+        // This isn't relevant on Mac as Menu bars don't live in the app window
+        supported(): boolean {
+            return process.platform !== "darwin";
+        },
         async read(): Promise<any> {
             return !global.mainWindow!.autoHideMenuBar;
         },
@@ -46,7 +52,10 @@ export const Settings: Record<string, Setting> = {
         },
     },
     "Electron.showTrayIcon": {
-        // not supported on macOS
+        // Things other than Mac support tray icons
+        supported(): boolean {
+            return process.platform !== "darwin";
+        },
         async read(): Promise<any> {
             return tray.hasTray();
         },
@@ -68,4 +77,39 @@ export const Settings: Record<string, Setting> = {
             Store.instance?.set("disableHardwareAcceleration", !value);
         },
     },
+    "Electron.enableContentProtection": {
+        // Unsupported on Linux https://www.electronjs.org/docs/latest/api/browser-window#winsetcontentprotectionenable-macos-windows
+        supported(): boolean {
+            return process.platform !== "linux";
+        },
+        async read(): Promise<any> {
+            return Store.instance?.get("enableContentProtection");
+        },
+        async write(value: any): Promise<void> {
+            global.mainWindow?.setContentProtection(value);
+            Store.instance?.set("enableContentProtection", value);
+        },
+    },
 };
+
+ipcMain.handle("getSupportedSettings", async () => {
+    const supportedSettings: Record<string, boolean> = {};
+    for (const [key, setting] of Object.entries(Settings)) {
+        supportedSettings[key] = setting.supported?.() ?? true;
+    }
+    return supportedSettings;
+});
+ipcMain.handle("setSettingValue", async (_ev, settingName: string, value: any) => {
+    const setting = Settings[settingName];
+    if (!setting) {
+        throw new Error(`Unknown setting: ${settingName}`);
+    }
+    await setting.write(value);
+});
+ipcMain.handle("getSettingValue", async (_ev, settingName: string) => {
+    const setting = Settings[settingName];
+    if (!setting) {
+        throw new Error(`Unknown setting: ${settingName}`);
+    }
+    return await setting.read();
+});

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -13,10 +13,10 @@ import Store from "./store.js";
 interface Setting {
     read(): Promise<any>;
     write(value: any): Promise<void>;
-    supported?(): boolean;
+    supported?(): boolean; // if undefined, the setting is always supported
 }
 
-export const Settings: Record<string, Setting> = {
+const Settings: Record<string, Setting> = {
     "Electron.autoLaunch": {
         async read(): Promise<any> {
             return global.launcher.isEnabled();

--- a/src/store.ts
+++ b/src/store.ts
@@ -83,6 +83,7 @@ interface StoreData {
     autoHideMenuBar: boolean;
     locale?: string | string[];
     disableHardwareAcceleration: boolean;
+    enableContentProtection: boolean;
     safeStorage?: Record<string, string>;
     /** the safeStorage backend used for the safeStorage data as written */
     safeStorageBackend?: SafeStorageBackend;
@@ -214,6 +215,10 @@ class Store extends ElectronStore<StoreData> {
                     anyOf: [{ type: "string" }, { type: "array", items: { type: "string" } }],
                 },
                 disableHardwareAcceleration: {
+                    type: "boolean",
+                    default: false,
+                },
+                enableContentProtection: {
                     type: "boolean",
                     default: false,
                 },


### PR DESCRIPTION
Fixes https://github.com/element-hq/element-desktop/issues/2380
Requires https://github.com/element-hq/element-web/pull/30098

https://github.com/user-attachments/assets/4238641d-a33f-4bfe-81fd-702115c99f0f