### PR TITLE
Add support for overlaying notification badges on the Windows Taskbar icon.

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
         "electron-window-state": "^5.0.3",
         "keytar-forked": "7.10.0",
         "minimist": "^1.2.6",
+        "png-to-ico": "^2.1.8",
         "uuid": "^11.0.0"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
         "electron-window-state": "^5.0.3",
         "keytar-forked": "7.10.0",
         "minimist": "^1.2.6",
-        "png-to-ico": "^2.1.1",
         "uuid": "^11.0.0"
     },
     "devDependencies": {

--- a/src/badge.ts
+++ b/src/badge.ts
@@ -1,3 +1,10 @@
+/*
+Copyright 2025 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
 import { app, ipcMain, type IpcMainEvent, nativeImage } from "electron";
 
 import { _t } from "./language-helper.js";

--- a/src/badge.ts
+++ b/src/badge.ts
@@ -1,0 +1,42 @@
+import { app, ipcMain, type IpcMainEvent, nativeImage } from "electron";
+
+import { _t } from "./language-helper.js";
+
+// Handles calculating the correct "badge" for the window, for notifications and error states.
+// Tray icon updates are handled in tray.ts
+
+if (process.platform === "win32") {
+    // We only use setOverlayIcon on Windows as it's only supported on that platform, but has good support
+    // from all the Windows variants we support.
+    // https://www.electronjs.org/docs/latest/api/browser-window#winsetoverlayiconoverlay-description-windows
+    ipcMain.on(
+        "setBadgeCount",
+        function (_ev: IpcMainEvent, count: number, imageBuffer?: Buffer, isError?: boolean): void {
+            if (count === 0) {
+                // Flash frame is set to true in ipc.ts "loudNotification"
+                global.mainWindow?.flashFrame(false);
+            }
+            if (imageBuffer) {
+                global.mainWindow?.setOverlayIcon(
+                    nativeImage.createFromBuffer(Buffer.from(imageBuffer)),
+                    isError
+                        ? _t("icon_overlay|description_error")
+                        : _t("icon_overlay|description_notifications", { count }),
+                );
+            } else {
+                global.mainWindow?.setOverlayIcon(null, "");
+            }
+        },
+    );
+} else {
+    // only set badgeCount on Mac/Linux, the docs say that only those platforms support it but turns out Electron
+    // has some Windows support too, and in some Windows environments this leads to two badges rendering atop
+    // each other. See https://github.com/vector-im/element-web/issues/16942
+    ipcMain.on("setBadgeCount", function (_ev: IpcMainEvent, count: number): void {
+        if (count === 0) {
+            // Flash frame is set to true in ipc.ts "loudNotification"
+            global.mainWindow?.flashFrame(false);
+        }
+        app.badgeCount = count;
+    });
+}

--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2018-2024 New Vector Ltd.
+Copyright 2018-2025 New Vector Ltd.
 Copyright 2017-2019 Michael Telatynski <7t3chguy@gmail.com>
 Copyright 2016 Aviral Dasgupta
 Copyright 2016 OpenMarket Ltd

--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -23,6 +23,7 @@ import minimist from "minimist";
 import "./ipc.js";
 import "./seshat.js";
 import "./settings.js";
+import "./badge.js";
 import * as tray from "./tray.js";
 import Store from "./store.js";
 import { buildMenuTemplate } from "./vectormenu.js";

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -35,6 +35,13 @@
     "file_menu": {
         "label": "File"
     },
+    "icon_overlay": {
+        "description_error": "Error",
+        "description_notifications": {
+            "one": "You have %(count)s unread notification.",
+            "other": "You have %(count)s unread notifications."
+        }
+    },
     "menu": {
         "hide": "Hide",
         "hide_others": "Hide Others",
@@ -76,13 +83,5 @@
         "bring_all_to_front": "Bring All to Front",
         "label": "Window",
         "zoom": "Zoom"
-    },
-    "icon_overlay": {
-        "description_notifications": {
-            "one": "You have %(count)s unread notification.",
-            "other": "You have %(count)s unread notifications."
-        },
-        "description_error": "Error"
     }
-        
 }

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -76,5 +76,13 @@
         "bring_all_to_front": "Bring All to Front",
         "label": "Window",
         "zoom": "Zoom"
+    },
+    "icon_overlay": {
+        "description_notifications": {
+            "one": "You have %(count)s unread notification.",
+            "other": "You have %(count)s unread notifications."
+        },
+        "description_error": "Error"
     }
+        
 }

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -20,18 +20,6 @@ ipcMain.on(
             // has some Windows support too, and in some Windows environments this leads to two badges rendering atop
             // each other. See https://github.com/vector-im/element-web/issues/16942
             app.badgeCount = count;
-        } else {
-            // similarly, we only use setOverlayIcon on Windows as it's only supported on that platform, but has good support
-            // from all the Windows variants we support.
-            // https://www.electronjs.org/docs/latest/api/browser-window#winsetoverlayiconoverlay-description-windows
-            if (imageBuffer && imageBufferDescription !== undefined) {
-                global.mainWindow?.setOverlayIcon(
-                    nativeImage.createFromBuffer(Buffer.from(imageBuffer)),
-                    imageBufferDescription,
-                );
-            } else {
-                global.mainWindow?.setOverlayIcon(null, "");
-            }
         }
         if (count === 0) {
             global.mainWindow?.flashFrame(false);

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -12,12 +12,18 @@ import { randomArray } from "./utils.js";
 import { getDisplayMediaCallback, setDisplayMediaCallback } from "./displayMediaCallback.js";
 import Store, { clearDataAndRelaunch } from "./store.js";
 
-ipcMain.on("setBadgeCount", function (_ev: IpcMainEvent, count: number): void {
+ipcMain.on("setBadgeCount", function (_ev: IpcMainEvent, count: number, imageBuffer?: Buffer, imageBufferDescription?: string): void {
     if (process.platform !== "win32") {
         // only set badgeCount on Mac/Linux, the docs say that only those platforms support it but turns out Electron
         // has some Windows support too, and in some Windows environments this leads to two badges rendering atop
         // each other. See https://github.com/vector-im/element-web/issues/16942
         app.badgeCount = count;
+    } else {
+        if (imageBuffer && imageBufferDescription !== undefined) {
+            global.mainWindow?.setOverlayIcon(nativeImage.createFromBuffer(Buffer.from(imageBuffer)), imageBufferDescription);
+        } else {
+            global.mainWindow?.setOverlayIcon(null, "");
+        }
     }
     if (count === 0) {
         global.mainWindow?.flashFrame(false);

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -12,23 +12,29 @@ import { randomArray } from "./utils.js";
 import { getDisplayMediaCallback, setDisplayMediaCallback } from "./displayMediaCallback.js";
 import Store, { clearDataAndRelaunch } from "./store.js";
 
-ipcMain.on("setBadgeCount", function (_ev: IpcMainEvent, count: number, imageBuffer?: Buffer, imageBufferDescription?: string): void {
-    if (process.platform !== "win32") {
-        // only set badgeCount on Mac/Linux, the docs say that only those platforms support it but turns out Electron
-        // has some Windows support too, and in some Windows environments this leads to two badges rendering atop
-        // each other. See https://github.com/vector-im/element-web/issues/16942
-        app.badgeCount = count;
-    } else {
-        if (imageBuffer && imageBufferDescription !== undefined) {
-            global.mainWindow?.setOverlayIcon(nativeImage.createFromBuffer(Buffer.from(imageBuffer)), imageBufferDescription);
+ipcMain.on(
+    "setBadgeCount",
+    function (_ev: IpcMainEvent, count: number, imageBuffer?: Buffer, imageBufferDescription?: string): void {
+        if (process.platform !== "win32") {
+            // only set badgeCount on Mac/Linux, the docs say that only those platforms support it but turns out Electron
+            // has some Windows support too, and in some Windows environments this leads to two badges rendering atop
+            // each other. See https://github.com/vector-im/element-web/issues/16942
+            app.badgeCount = count;
         } else {
-            global.mainWindow?.setOverlayIcon(null, "");
+            if (imageBuffer && imageBufferDescription !== undefined) {
+                global.mainWindow?.setOverlayIcon(
+                    nativeImage.createFromBuffer(Buffer.from(imageBuffer)),
+                    imageBufferDescription,
+                );
+            } else {
+                global.mainWindow?.setOverlayIcon(null, "");
+            }
         }
-    }
-    if (count === 0) {
-        global.mainWindow?.flashFrame(false);
-    }
-});
+        if (count === 0) {
+            global.mainWindow?.flashFrame(false);
+        }
+    },
+);
 
 let focusHandlerAttached = false;
 ipcMain.on("loudNotification", function (): void {

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2022-2024 New Vector Ltd.
+Copyright 2022-2025 New Vector Ltd.
 
 SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
 Please see LICENSE files in the repository root for full details.

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -12,21 +12,6 @@ import { randomArray } from "./utils.js";
 import { getDisplayMediaCallback, setDisplayMediaCallback } from "./displayMediaCallback.js";
 import Store, { clearDataAndRelaunch } from "./store.js";
 
-ipcMain.on(
-    "setBadgeCount",
-    function (_ev: IpcMainEvent, count: number, imageBuffer?: Buffer, imageBufferDescription?: string): void {
-        if (process.platform !== "win32") {
-            // only set badgeCount on Mac/Linux, the docs say that only those platforms support it but turns out Electron
-            // has some Windows support too, and in some Windows environments this leads to two badges rendering atop
-            // each other. See https://github.com/vector-im/element-web/issues/16942
-            app.badgeCount = count;
-        }
-        if (count === 0) {
-            global.mainWindow?.flashFrame(false);
-        }
-    },
-);
-
 let focusHandlerAttached = false;
 ipcMain.on("loudNotification", function (): void {
     if (process.platform === "win32" || process.platform === "linux") {

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -21,6 +21,9 @@ ipcMain.on(
             // each other. See https://github.com/vector-im/element-web/issues/16942
             app.badgeCount = count;
         } else {
+            // similarly, we only use setOverlayIcon on Windows as it's only supported on that platform, but has good support
+            // from all the Windows variants we support.
+            // https://www.electronjs.org/docs/latest/api/browser-window#winsetoverlayiconoverlay-description-windows
             if (imageBuffer && imageBufferDescription !== undefined) {
                 global.mainWindow?.setOverlayIcon(
                     nativeImage.createFromBuffer(Buffer.from(imageBuffer)),

--- a/src/preload.cts
+++ b/src/preload.cts
@@ -55,13 +55,17 @@ contextBridge.exposeInMainWorld("electron", {
         sessionId: string;
         config: IConfigOptions;
         supportedSettings: Record<string, boolean>;
+        /**
+         * Do we need to render badge overlays for new notifications?
+         */
+        supportsBadgeOverlay: boolean;
     }> {
         const [{ protocol, sessionId }, config, supportedSettings] = await Promise.all([
             ipcRenderer.invoke("getProtocol"),
             ipcRenderer.invoke("getConfig"),
             ipcRenderer.invoke("getSupportedSettings"),
         ]);
-        return { protocol, sessionId, config, supportedSettings };
+        return { protocol, sessionId, config, supportedSettings, supportsBadgeOverlay: process.platform === "win32" };
     },
 
     async setSettingValue(settingName: string, value: any): Promise<void> {

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 New Vector Ltd.
+Copyright 2024-2025 New Vector Ltd.
 Copyright 2017 Karl Glatz <karl@glatz.biz>
 Copyright 2017 OpenMarket Ltd
 

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
-import { app, Tray, Menu, nativeImage, ipcMain, IpcMainEvent } from "electron";
+import { app, Tray, Menu, nativeImage, ipcMain, type IpcMainEvent } from "electron";
 import { v5 as uuidv5 } from "uuid";
 
 import { _t } from "./language-helper.js";
@@ -102,7 +102,7 @@ export function create(config: IConfig): void {
             if (favicons[0] === lastFavicon) return;
             lastFavicon = favicons[0];
 
-            let newFavicon = nativeImage.createFromDataURL(favicons[0]);
+            const newFavicon = nativeImage.createFromDataURL(favicons[0]);
             trayIcon?.setImage(newFavicon);
             global.mainWindow?.setIcon(newFavicon);
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2243,7 +2243,7 @@
     "@types/node" "*"
     form-data "^4.0.0"
 
-"@types/node@*", "@types/node@18.19.115", "@types/node@^22.7.7":
+"@types/node@*", "@types/node@18.19.115", "@types/node@^17.0.36", "@types/node@^22.7.7":
   version "18.19.115"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.115.tgz#cd94caf14472021b4443c99bcd7aac6bb5c4f672"
   integrity sha512-kNrFiTgG4a9JAn1LMQeLOv3MvXIPokzXziohMrMsvpYgLpdEt/mMiVYc4sGKtDfyxM5gIDF4VgrPRyCw4fHOYg==
@@ -6236,6 +6236,20 @@ pluralizers@^0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/pluralizers/-/pluralizers-0.1.7.tgz#8d38dd0a1b660e739b10ab2eab10b684c9d50142"
   integrity sha512-mw6AejUiCaMQ6uPN9ObjJDTnR5AnBSmnHHy3uVTbxrSFSxO5scfwpTs8Dxyb6T2v7GSulhvOq+pm9y+hXUvtOA==
+
+png-to-ico@^2.1.8:
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/png-to-ico/-/png-to-ico-2.1.8.tgz#fdc2eda6f197df1d6c33400707e36c3b802ac6dd"
+  integrity sha512-Nf+IIn/cZ/DIZVdGveJp86NG5uNib1ZXMiDd/8x32HCTeKSvgpyg6D/6tUBn1QO/zybzoMK0/mc3QRgAyXdv9w==
+  dependencies:
+    "@types/node" "^17.0.36"
+    minimist "^1.2.6"
+    pngjs "^6.0.0"
+
+pngjs@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-6.0.0.tgz#ca9e5d2aa48db0228a52c419c3308e87720da821"
+  integrity sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==
 
 possible-typed-array-names@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2243,7 +2243,7 @@
     "@types/node" "*"
     form-data "^4.0.0"
 
-"@types/node@*", "@types/node@18.19.115", "@types/node@^17.0.36", "@types/node@^22.7.7":
+"@types/node@*", "@types/node@18.19.115", "@types/node@^22.7.7":
   version "18.19.115"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.115.tgz#cd94caf14472021b4443c99bcd7aac6bb5c4f672"
   integrity sha512-kNrFiTgG4a9JAn1LMQeLOv3MvXIPokzXziohMrMsvpYgLpdEt/mMiVYc4sGKtDfyxM5gIDF4VgrPRyCw4fHOYg==
@@ -6236,20 +6236,6 @@ pluralizers@^0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/pluralizers/-/pluralizers-0.1.7.tgz#8d38dd0a1b660e739b10ab2eab10b684c9d50142"
   integrity sha512-mw6AejUiCaMQ6uPN9ObjJDTnR5AnBSmnHHy3uVTbxrSFSxO5scfwpTs8Dxyb6T2v7GSulhvOq+pm9y+hXUvtOA==
-
-png-to-ico@^2.1.1:
-  version "2.1.8"
-  resolved "https://registry.yarnpkg.com/png-to-ico/-/png-to-ico-2.1.8.tgz#fdc2eda6f197df1d6c33400707e36c3b802ac6dd"
-  integrity sha512-Nf+IIn/cZ/DIZVdGveJp86NG5uNib1ZXMiDd/8x32HCTeKSvgpyg6D/6tUBn1QO/zybzoMK0/mc3QRgAyXdv9w==
-  dependencies:
-    "@types/node" "^17.0.36"
-    minimist "^1.2.6"
-    pngjs "^6.0.0"
-
-pngjs@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-6.0.0.tgz#ca9e5d2aa48db0228a52c419c3308e87720da821"
-  integrity sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==
 
 possible-typed-array-names@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Fixes https://github.com/element-hq/element-desktop/issues/762
Requires https://github.com/element-hq/element-web/pull/30315

This uses https://www.electronjs.org/docs/latest/api/browser-window#winsetoverlayiconoverlay-description-windows to add a badge to the taskbar icon on Windows to show how many outstanding notifications there are, or if the client goes offline.


https://github.com/user-attachments/assets/042ddc96-a4c4-46e8-a644-6cdb928180de



## Checklist

- [x] Ensure your code works with manual testing.
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-desktop)
