### PR TITLE
Reduce macos titlebar height with the new room list and expand the existing border

### DIFF
--- a/src/macos-titlebar.ts
+++ b/src/macos-titlebar.ts
@@ -117,6 +117,12 @@ export function setupMacosTitleBar(window: BrowserWindow): void {
                 height: 20px;
                 -webkit-app-region: drag;
             }
+            
+            .mx_LeftPanel_newRoomList::before {
+                /* Aligned with the room header */
+                height: 13px;
+                border-right: 1px solid var(--cpd-color-bg-subtle-primary);
+            }
 
             .mx_RoomView::before,
             .mx_SpaceRoomView::before {


### PR DESCRIPTION
This PR fix the macos tittle bar when the new room list is enabled:
- Reduce the title bar height
- Expand the existing border between the room header and the room list
- TODO

<img width="1028" height="770" alt="image" src="https://github.com/user-attachments/assets/d2d1aaa7-e46b-40ae-a270-43e1dd99fcbf" />
