### PR TITLE
Allow specifying the webapp artifact name for the reusable workflows

### DIFF
--- a/.github/workflows/build_linux.yaml
+++ b/.github/workflows/build_linux.yaml
@@ -20,6 +20,11 @@ on:
                 type: boolean
                 required: false
                 description: "Whether to run the blob report"
+            prepare-artifact-name:
+                type: string
+                required: false
+                description: "The name of the prepare artifact to use, defaults to 'webapp'"
+                default: "webapp"
 env:
     SQLCIPHER_BUNDLED: ${{ inputs.sqlcipher == 'static' && '1' || '' }}
     MAX_GLIBC: 2.31 # bullseye-era glibc, used by glibc-check.sh
@@ -64,7 +69,7 @@ jobs:
 
             - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
               with:
-                  name: webapp
+                  name: ${{ inputs.prepare-artifact-name }}
 
             - name: Cache .hak
               id: cache

--- a/.github/workflows/build_macos.yaml
+++ b/.github/workflows/build_macos.yaml
@@ -31,6 +31,11 @@ on:
                 type: boolean
                 required: false
                 description: "Whether to run the blob report"
+            prepare-artifact-name:
+                type: string
+                required: false
+                description: "The name of the prepare artifact to use, defaults to 'webapp'"
+                default: "webapp"
 permissions: {} # No permissions required
 jobs:
     build:
@@ -41,7 +46,7 @@ jobs:
 
             - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
               with:
-                  name: webapp
+                  name: ${{ inputs.prepare-artifact-name }}
 
             - name: Cache .hak
               id: cache

--- a/.github/workflows/build_windows.yaml
+++ b/.github/workflows/build_windows.yaml
@@ -34,6 +34,11 @@ on:
                 type: boolean
                 required: false
                 description: "Whether to run the blob report"
+            prepare-artifact-name:
+                type: string
+                required: false
+                description: "The name of the prepare artifact to use, defaults to 'webapp'"
+                default: "webapp"
 permissions: {} # No permissions required
 jobs:
     build:
@@ -69,7 +74,7 @@ jobs:
 
             - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
               with:
-                  name: webapp
+                  name: ${{ inputs.prepare-artifact-name }}
 
             - name: Cache .hak
               id: cache


### PR DESCRIPTION
This is to make custom builds simpler