### PR TITLE
feat: Clear session lock on app startup.

### DIFF
--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -518,6 +518,14 @@ app.on("ready", async () => {
         }
     });
 
+    // Clear the SDK session lock ping. Since we obtain an app single instance lock during initialisation,
+    // we are guaranteed to be the only Element Desktop process running.
+    global.mainWindow.webContents
+        .executeJavaScript("window.localStorage.removeItem('react_sdk_session_lock_ping');")
+        .catch(() => {
+            console.log("Failed to clear existing session lock");
+        });
+
     global.mainWindow.on("closed", () => {
         global.mainWindow = null;
     });


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Remove `react_sdk_session_lock_ping` from `localStorage` on app startup. Since we [take out](https://github.com/element-hq/element-desktop/blob/bcde9afce9077e7a54d8d6cb5076db9ec710aa38/src/electron-main.ts#L284) a single instance lock during app initialization, we can guarantee only a single `element-desktop` process runs.

## Checklist

- [x] Ensure your code works with manual testing.
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-desktop)
