### PR TITLE
Update Electron to v38.1.0 to fix Kernel crash on multi-GPU systems

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
         "app-builder-lib": "26.0.20",
         "chokidar": "^4.0.0",
         "detect-libc": "^2.0.0",
-        "electron": "37.4.0",
+        "electron": "38.1.0",
         "electron-builder": "26.0.20",
         "electron-builder-squirrel-windows": "26.0.20",
         "electron-devtools-installer": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3697,10 +3697,10 @@ electron-winstaller@5.4.0:
   optionalDependencies:
     "@electron/windows-sign" "^1.1.2"
 
-electron@37.4.0:
-  version "37.4.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-37.4.0.tgz#08b2eff9d6250fac7b298f17f93946ecd586f38e"
-  integrity sha512-HhsSdWowE5ODOeWNc/323Ug2C52mq/TqNBG+4uMeOA3G2dMXNc/nfyi0RYu1rJEgiaJLEjtHveeZZaYRYFsFCQ==
+electron@38.1.0:
+  version "38.1.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-38.1.0.tgz#caebed7f3d7b1d43a9d01811db1f62744a753aa4"
+  integrity sha512-ypA8GF8RU4HD5pA1sa0/2U8k+92EPP2c7pX+3XbgB760F7OmqrFXtYkOilVw6HfV4+lk88XxqigmsUKTACQYoQ==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^22.7.7"


### PR DESCRIPTION
Closes #2543

## Checklist

- [x] Ensure your code works with manual testing.
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-desktop)
