### PR TITLE
Remove GTK workaround

### DIFF
--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -301,11 +301,6 @@ app.commandLine.appendSwitch("--enable-usermedia-screen-capturing");
 if (!app.commandLine.hasSwitch("enable-features")) {
     app.commandLine.appendSwitch("enable-features", "WebRTCPipeWireCapturer");
 }
-// Workaround bug in electron 36:https://github.com/electron/electron/issues/46538
-// Hopefully this will no longer be needed soon and can be removed
-if (process.platform === "linux") {
-    app.commandLine.appendSwitch("gtk-version", "3");
-}
 
 const gotLock = app.requestSingleInstanceLock();
 if (!gotLock) {


### PR DESCRIPTION
No longer needed as of 37 as per https://github.com/electron/electron/issues/46538