### PR TITLE
Wait for Electron to be ready before we fire syntax error dialog

### DIFF
--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -211,6 +211,7 @@ function loadConfig(): Promise<void> {
             global.vectorConfig = Object.assign(global.vectorConfig, localConfig);
         } catch (e) {
             if (e instanceof SyntaxError) {
+                await app.whenReady();
                 void dialog.showMessageBox({
                     type: "error",
                     title: `Your ${global.vectorConfig.brand || "Element"} is misconfigured`,


### PR DESCRIPTION
Fixes https://github.com/element-hq/element-desktop/issues/2658

```
(node:2691) UnhandledPromiseRejectionWarning: Error: dialog module can only be used after app is ready
    at checkAppInitialized (node:electron/js2c/browser_init:2:23031)
    at messageBox (node:electron/js2c/browser_init:2:24921)
    at Object.showMessageBox (node:electron/js2c/browser_init:2:21266)
    at actuallyLoadConfig (file:///opt/Element/resources/app.asar/lib/electron-main.js:181:29)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async configureSentry (file:///opt/Element/resources/app.asar/lib/electron-main.js:206:5)