### PR TITLE
Fix `Ctrl+Q` not closing the app

### DIFF
--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -505,8 +505,8 @@ app.on("ready", async () => {
 
     global.mainWindow.webContents.on("before-input-event", (event: Event, input: Input): void => {
         const exitShortcutPressed =
-        input.type === "keyDown" && exitShortcuts.some((shortcutFn) => shortcutFn(input, process.platform));
-        
+            input.type === "keyDown" && exitShortcuts.some((shortcutFn) => shortcutFn(input, process.platform));
+
         // We only care about the exit shortcuts here
         if (!exitShortcutPressed || !global.mainWindow) return;
 


### PR DESCRIPTION
Closes https://github.com/element-hq/element-desktop/issues/681

We show a dialog when the user presses `Ctrl+Q` key combination. If the user clicks `Cancel`, we prevent the event from doing its thing. But otherwise, we do nothing with the expectation that electron's default behavior takes over and the app exits.

This doesn't seem to work so have added code to explicitly exit the app. 