### PR TITLE
Fix issues with quit logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
         "electron-builder": "26.6.0",
         "electron-builder-squirrel-windows": "26.6.0",
         "electron-devtools-installer": "^4.0.0",
+        "electron-playwright-helpers": "^2.1.0",
         "eslint": "^8.26.0",
         "eslint-config-google": "^0.14.0",
         "eslint-config-prettier": "^10.0.0",

--- a/playwright/element-desktop-test.ts
+++ b/playwright/element-desktop-test.ts
@@ -12,6 +12,7 @@ import path, { dirname } from "node:path";
 import os from "node:os";
 import { fileURLToPath } from "node:url";
 import { PassThrough } from "node:stream";
+import { stubDialog } from "electron-playwright-helpers";
 
 /**
  * A PassThrough stream that captures all data written to it.
@@ -111,6 +112,8 @@ export const test = base.extend<Fixtures>({
     page: async ({ app }, use) => {
         const window = await app.firstWindow();
         await use(window);
+        // EW may be configured to ask for confirmation before the app exits.
+        await stubDialog(app, "showMessageBoxSync", 1);
         await app.close().catch((e) => {
             console.error(e);
         });

--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -560,6 +560,7 @@ app.on("ready", async () => {
                 }) === 0;
             if (shouldCancelCloseRequest) {
                 e.preventDefault();
+                global.appQuitting = false;
                 return false;
             }
         }

--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -507,15 +507,44 @@ app.on("ready", async () => {
         const exitShortcutPressed =
             input.type === "keyDown" && exitShortcuts.some((shortcutFn) => shortcutFn(input, process.platform));
 
-        // We only care about the exit shortcuts here
-        if (!exitShortcutPressed || !global.mainWindow) return;
+        // Early return if:
+        // 1. Keys that were pressed are not shortcuts for exiting the app
+        // 2. Electron mainWindow is null for some reason
+        // 3. The application is already in the process of quitting
+        if (!exitShortcutPressed || !global.mainWindow || global.appQuitting) return;
 
         // Prevent the default behaviour
         event.preventDefault();
 
-        // Let's ask the user if they really want to exit the app
+        // Check if the user expects us to minimize to tray instead of quitting the app
+        const shouldMinimize = store.get("minimizeToTray") && (tray.hasTray() || process.platform === "darwin");
+        if (shouldMinimize) {
+            // On Mac, closing the window just hides it
+            // (this is generally how single-window Mac apps
+            // behave, eg. Mail.app)
+
+            if (global.mainWindow?.isFullScreen()) {
+                global.mainWindow.once("leave-full-screen", () => global.mainWindow?.hide());
+                global.mainWindow.setFullScreen(false);
+            } else {
+                global.mainWindow?.hide();
+            }
+
+            return;
+        }
+
+        // Quit the app; rest of the quit logic is on the close event handler below.
+        app.quit();
+    });
+
+    global.mainWindow.on("closed", () => {
+        global.mainWindow = null;
+    });
+
+    global.mainWindow.on("close", async (e) => {
+        // Check if the user expects us to ask for confirmation before quitting the app
         const shouldWarnBeforeExit = store.get("warnBeforeExit", true);
-        if (shouldWarnBeforeExit) {
+        if (shouldWarnBeforeExit && global.mainWindow) {
             const shouldCancelCloseRequest =
                 dialog.showMessageBoxSync(global.mainWindow, {
                     type: "question",
@@ -529,33 +558,10 @@ app.on("ready", async () => {
                     defaultId: 1,
                     cancelId: 0,
                 }) === 0;
-            if (shouldCancelCloseRequest) return;
-        }
-
-        // Exit the app
-        app.exit();
-    });
-
-    global.mainWindow.on("closed", () => {
-        global.mainWindow = null;
-    });
-    global.mainWindow.on("close", async (e) => {
-        // If we are not quitting and have a tray icon then minimize to tray
-        if (!global.appQuitting && (tray.hasTray() || process.platform === "darwin")) {
-            // On Mac, closing the window just hides it
-            // (this is generally how single-window Mac apps
-            // behave, eg. Mail.app)
-            e.preventDefault();
-
-            if (global.mainWindow?.isFullScreen()) {
-                global.mainWindow.once("leave-full-screen", () => global.mainWindow?.hide());
-
-                global.mainWindow.setFullScreen(false);
-            } else {
-                global.mainWindow?.hide();
+            if (shouldCancelCloseRequest) {
+                e.preventDefault();
+                return false;
             }
-
-            return false;
         }
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -894,7 +894,7 @@
     ajv "^6.12.0"
     ajv-keywords "^3.4.1"
 
-"@electron/asar@3.4.1", "@electron/asar@^3.3.1":
+"@electron/asar@3.4.1", "@electron/asar@^3.2.4", "@electron/asar@^3.3.1":
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/@electron/asar/-/asar-3.4.1.tgz#4e9196a4b54fba18c56cd8d5cac67c5bdc588065"
   integrity sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA==
@@ -3378,6 +3378,13 @@ electron-devtools-installer@^4.0.0:
   integrity sha512-9Tntu/jtfSn0n6N/ZI6IdvRqXpDyLQiDuuIbsBI+dL+1Ef7C8J2JwByw58P3TJiNeuqyV3ZkphpNWuZK5iSY2w==
   dependencies:
     unzip-crx-3 "^0.2.0"
+
+electron-playwright-helpers@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/electron-playwright-helpers/-/electron-playwright-helpers-2.1.0.tgz#bafda622b236a53cdcfb7e8d62f3d62550fdbfce"
+  integrity sha512-aQOefS1irz/Ou6IYuTE34ZLmIKVHKoTGUwkVuwu2P5iguuMTLtsg6CFImsWu0cabRPVZ1NgEpcGPumFZNDdrqA==
+  dependencies:
+    "@electron/asar" "^3.2.4"
 
 electron-publish@26.6.0:
   version "26.6.0"


### PR DESCRIPTION
Closes https://github.com/element-hq/element-web/issues/32504

Expectations are as follows:
- If the user has `Show tray icon and minimise window to it on close` turned on, the exit shortcuts should minimize to tray instead of exiting the application. There's two exceptions here:
    1. CTRL + W (and equivalent mac shortcut) should still exit the application.
    2. Selecting Quit from the menu should still exit the application.
- If the user has `Warn before quitting` turned on, the application must present a confirmation dialog before exiting the application. Previously this only happened on certain keyboard shortcuts.
    - This confirmation should not be shown if the "exit" shortcut is configured to minimize to tray instead of exiting the application. 