### PR TITLE
Add audio capture support for pipewire

### DIFF
--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -573,14 +573,17 @@ app.on("ready", async () => {
     webContentsHandler(global.mainWindow.webContents);
 
     session.defaultSession.setDisplayMediaRequestHandler(
-        (_, callback) => {
+        (request, callback) => {
             if (process.env.XDG_SESSION_TYPE === "wayland") {
                 // On Wayland, calling getSources() opens the xdg-desktop-portal picker.
                 // The user can only select a single source there, so Electron will return an array with exactly one entry.
                 desktopCapturer
                     .getSources({ types: ["screen", "window"] })
                     .then((sources) => {
-                        callback({ video: sources[0] });
+                        callback({ 
+                            video: sources[0],
+                            audio: request.frame ? "loopback" : "loopback"
+                        });
                     })
                     .catch((err) => {
                         // If the user cancels the dialog an error occurs "Failed to get sources"


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [x] Ensure your code works with manual testing.
- [ ] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-desktop)

This adds audio screen share support to element-desktop/wayland. I tested with sway/xdg-desktop-portal-wlr. When starting a screen share it shares the whole desktop audio (xdg-desktop-portal-wlr doesn't even have a way to share only a single window so there is no way around this) --> there is no echo.

Partially fixes: https://github.com/element-hq/element-call/issues/3657

I don't have a way to test on windows/macos so I only touched the wayland logic. Feel free to add additional commits to this mr.