### PR TITLE
Add screen share audio capture support

### DIFF
--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -580,7 +580,7 @@ app.on("ready", async () => {
                 desktopCapturer
                     .getSources({ types: ["screen", "window"] })
                     .then((sources) => {
-                        callback({ video: sources[0] });
+                        callback({ video: sources[0], audio: "loopback" });
                     })
                     .catch((err) => {
                         // If the user cancels the dialog an error occurs "Failed to get sources"

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -143,7 +143,7 @@ ipcMain.on("ipcCall", async function (_ev: IpcMainEvent, payload) {
             }));
             break;
         case "callDisplayMediaCallback":
-            await getDisplayMediaCallback()?.({ video: args[0] });
+            await getDisplayMediaCallback()?.({ video: args[0], audio: "loopback" });
             setDisplayMediaCallback(null);
             ret = null;
             break;


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [x] Ensure your code works with manual testing.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-desktop)

This adds audio screen share support to element-desktop. I tested with sway/xdg-desktop-portal-wlr. When starting a screen share it shares the whole desktop audio (xdg-desktop-portal-wlr doesn't even have a way to share only a single window so there is no way around this) --> there is no echo. 
Also works with Gnome --> also always sharing the whole desktop audio.

Also tested on Windows, does not work atm. --> Draft

Potentially fixes: https://github.com/element-hq/element-call/issues/3657

I don't have a way to test on macos.