### PR TITLE
Fix app name in Windows notifications

### DIFF
--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -46,12 +46,28 @@ import { setupMacosTitleBar } from "./macos-titlebar.js";
 import { type Json, loadJsonFile } from "./utils.js";
 import { setupMediaAuth } from "./media-auth.js";
 import { readBuildConfig } from "./build-config.js";
+import { checkSquirrelHooks } from "./squirrelhooks.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const argv = minimist(process.argv, {
     alias: { help: "h" },
 });
+
+const buildConfig = readBuildConfig();
+
+// This is required to make notification handlers work
+// on Windows 8.1/10/11 (and is a noop on other platforms);
+// It must also match the ID found in 'electron-builder'
+// in order to get the title and icon to show up correctly.
+// Ref: https://stackoverflow.com/a/77314604/3525780
+// Must be done before checkSquirrelHooks() as the hook needs
+// to know what AppUserModelID to set on the shortcut.
+app.setAppUserModelId(buildConfig.appId);
+
+if (checkSquirrelHooks()) {
+    process.exit(1);
+}
 
 if (argv["help"]) {
     console.log("Options:");
@@ -84,7 +100,6 @@ function isRealUserDataDir(d: string): boolean {
     return fs.existsSync(path.join(d, "IndexedDB"));
 }
 
-const buildConfig = readBuildConfig();
 const protocolHandler = new ProtocolHandler(buildConfig.protocol);
 
 // check if we are passed a profile in the SSO callback url
@@ -626,9 +641,3 @@ app.on("second-instance", (ev, commandLine, workingDirectory) => {
     }
 });
 
-// This is required to make notification handlers work
-// on Windows 8.1/10/11 (and is a noop on other platforms);
-// It must also match the ID found in 'electron-builder'
-// in order to get the title and icon to show up correctly.
-// Ref: https://stackoverflow.com/a/77314604/3525780
-app.setAppUserModelId(buildConfig.appId);

--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -640,4 +640,3 @@ app.on("second-instance", (ev, commandLine, workingDirectory) => {
         global.mainWindow.focus();
     }
 });
-

--- a/src/squirrelhooks.ts
+++ b/src/squirrelhooks.ts
@@ -28,7 +28,7 @@ function runUpdateExe(args: string[]): Promise<void> {
     });
 }
 
-function checkSquirrelHooks(): boolean {
+export function checkSquirrelHooks(): boolean {
     if (process.platform !== "win32") return false;
     const cmd = process.argv[1];
     const target = path.basename(process.execPath);
@@ -50,8 +50,4 @@ function checkSquirrelHooks(): boolean {
         default:
             return false;
     }
-}
-
-if (checkSquirrelHooks()) {
-    process.exit(1);
 }


### PR DESCRIPTION
Set the App user model ID before running squirrel hooks, as per comment

Fixes https://github.com/element-hq/element-web/issues/32300

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Ensure your code works with manual testing.
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-desktop)
