### PR TITLE
Feat: screenshare audio sharing in Linux (with pipewire)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 /lib
 /webapp
 /webapp.asar
+# Generated from @vector-im/compound-design-tokens at build time
+/build/compound
 /packages
 /deploys
 node_modules/

--- a/build/audio-picker.html
+++ b/build/audio-picker.html
@@ -10,41 +10,12 @@ Please see LICENSE files in the repository root for full details.
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';">
+    <link rel="stylesheet" href="compound/compound-design-tokens.css">
     <title id="page-title">Share Audio</title>
     <style>
         :root {
-            /* Compound Design Tokens — dark theme resolved values
-             * from @vector-im/compound-design-tokens */
-            --color-bg-canvas: var(--cpd-color-bg-canvas-default, #101317);
-            --color-bg-subtle: var(--cpd-color-bg-subtle-primary, #26282d);
-            --color-bg-subtle-hover: var(--cpd-color-bg-action-secondary-hovered, hsla(286, 31%, 82%, 0.04));
-            --color-bg-accent: var(--cpd-color-bg-accent-selected, hsl(151, 100%, 7%));
-            --color-border-accent: var(--cpd-color-border-accent-subtle, #005a43);
-            --color-accent: var(--cpd-color-bg-accent-rest, #129a78);
-            --color-accent-hover: var(--cpd-color-bg-accent-hovered, #17ac84);
-            --color-text-primary: var(--cpd-color-text-primary, #ebeef2);
-            --color-text-secondary: var(--cpd-color-text-secondary, #808994);
-            --color-text-muted: var(--cpd-color-text-disabled, #656c76);
-            --color-border-subtle: var(--cpd-color-border-interactive-secondary, #3c3f44);
-            --color-border-interactive: var(--cpd-color-border-interactive-primary, #656c76);
-            --color-bg-button-secondary: var(--cpd-color-bg-action-secondary-rest, #101317);
-            --color-bg-button-secondary-hover: var(--cpd-color-bg-action-secondary-hovered, hsla(286, 31%, 82%, 0.04));
-            --color-bg-error: var(--cpd-color-bg-critical-subtle, #3e0000);
-            --color-border-error: var(--cpd-color-border-critical-subtle, #710000);
-            --color-text-error: var(--cpd-color-text-critical-primary, #fd3e3c);
-            --color-focus-ring: var(--cpd-color-border-focused, #4187eb);
-
-            /* Spacing scale */
-            --space-xs: 4px;
-            --space-sm: 8px;
-            --space-md: 12px;
-            --space-lg: 16px;
-            --space-xl: 20px;
-
-            /* Border radius */
+            /* Local tokens — no Compound equivalents */
             --radius-md: 8px;
-
-            /* Transitions */
             --transition-fast: 0.15s ease;
         }
 
@@ -61,10 +32,10 @@ Please see LICENSE files in the repository root for full details.
         }
 
         body {
-            font-family: var(--cpd-font-family-sans, Inter), "Helvetica Neue", "Segoe UI", Roboto, Ubuntu, "Fira Sans", "Noto Sans", Arial, sans-serif;
-            background: var(--color-bg-canvas);
-            color: var(--color-text-primary);
-            padding: var(--space-xl);
+            font-family: var(--cpd-font-family-sans);
+            background: var(--cpd-color-bg-canvas-default);
+            color: var(--cpd-color-text-primary);
+            padding: var(--cpd-space-5x);
             min-height: 100vh;
             display: flex;
             flex-direction: column;
@@ -78,27 +49,26 @@ Please see LICENSE files in the repository root for full details.
         }
 
         h1 {
-            font-size: 18px;
-            font-weight: 600;
-            margin-bottom: var(--space-sm);
+            font: var(--cpd-font-heading-sm-semibold);
+            margin-bottom: var(--cpd-space-2x);
         }
 
         .subtitle {
-            font-size: 13px;
-            color: var(--color-text-secondary);
-            margin-bottom: var(--space-xl);
+            font: var(--cpd-font-body-sm-regular);
+            color: var(--cpd-color-text-secondary);
+            margin-bottom: var(--cpd-space-5x);
         }
 
         .options-container {
             flex: 1;
             overflow-y: auto;
-            margin-bottom: var(--space-lg);
+            margin-bottom: var(--cpd-space-4x);
         }
 
         /* Scrollbar styling */
         .options-container::-webkit-scrollbar,
         .app-list::-webkit-scrollbar {
-            width: 6px;
+            width: var(--cpd-space-1-5x);
         }
 
         .options-container::-webkit-scrollbar-track,
@@ -108,47 +78,47 @@ Please see LICENSE files in the repository root for full details.
 
         .options-container::-webkit-scrollbar-thumb,
         .app-list::-webkit-scrollbar-thumb {
-            background: var(--color-border-subtle);
+            background: var(--cpd-color-border-interactive-secondary);
             border-radius: 3px;
         }
 
         .options-container::-webkit-scrollbar-thumb:hover,
         .app-list::-webkit-scrollbar-thumb:hover {
-            background: var(--color-border-interactive);
+            background: var(--cpd-color-border-interactive-primary);
         }
 
         .option {
             display: flex;
             align-items: center;
-            padding: 14px var(--space-lg);
+            padding: var(--cpd-space-3x) var(--cpd-space-4x);
             border-radius: var(--radius-md);
-            margin-bottom: var(--space-sm);
+            margin-bottom: var(--cpd-space-2x);
             cursor: pointer;
-            background: var(--color-bg-subtle);
+            background: var(--cpd-color-bg-subtle-primary);
             border: 2px solid transparent;
             transition: background var(--transition-fast), border-color var(--transition-fast);
             outline: none;
         }
 
         .option:hover {
-            background: var(--color-bg-subtle-hover);
+            background: var(--cpd-color-bg-action-secondary-hovered);
         }
 
         .option:focus-visible {
-            box-shadow: 0 0 0 2px var(--color-focus-ring);
+            box-shadow: 0 0 0 2px var(--cpd-color-border-focused);
         }
 
         .option[aria-checked="true"] {
-            background: var(--color-bg-accent);
-            border-color: var(--color-border-accent);
+            background: var(--cpd-color-bg-accent-selected);
+            border-color: var(--cpd-color-border-accent-subtle);
         }
 
         .option-radio {
             width: 18px;
             height: 18px;
-            border: 2px solid var(--color-border-interactive);
+            border: 2px solid var(--cpd-color-border-interactive-primary);
             border-radius: 50%;
-            margin-right: 14px;
+            margin-right: var(--cpd-space-3x);
             display: flex;
             align-items: center;
             justify-content: center;
@@ -157,7 +127,7 @@ Please see LICENSE files in the repository root for full details.
         }
 
         .option[aria-checked="true"] .option-radio {
-            border-color: var(--color-border-accent);
+            border-color: var(--cpd-color-border-accent-subtle);
         }
 
         .option[aria-checked="true"] .option-radio::after {
@@ -165,7 +135,7 @@ Please see LICENSE files in the repository root for full details.
             width: 10px;
             height: 10px;
             border-radius: 50%;
-            background: var(--color-accent);
+            background: var(--cpd-color-bg-accent-rest);
         }
 
         .option-content {
@@ -174,26 +144,24 @@ Please see LICENSE files in the repository root for full details.
         }
 
         .option-label {
-            font-size: 14px;
-            font-weight: 500;
+            font: var(--cpd-font-body-md-medium);
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;
         }
 
         .option-description {
-            font-size: 12px;
-            color: var(--color-text-secondary);
-            margin-top: 2px;
+            font: var(--cpd-font-body-xs-regular);
+            color: var(--cpd-color-text-secondary);
+            margin-top: var(--cpd-space-0-5x);
         }
 
         .section-header {
-            font-size: 12px;
-            font-weight: 600;
-            color: var(--color-text-secondary);
+            font: var(--cpd-font-body-xs-semibold);
+            color: var(--cpd-color-text-secondary);
             text-transform: uppercase;
             letter-spacing: 0.5px;
-            margin: var(--space-xl) 0 var(--space-md);
+            margin: var(--cpd-space-5x) 0 var(--cpd-space-3x);
         }
 
         .app-list {
@@ -204,25 +172,24 @@ Please see LICENSE files in the repository root for full details.
 
         .buttons {
             display: flex;
-            gap: var(--space-md);
-            padding-top: var(--space-sm);
-            border-top: 1px solid var(--color-border-subtle);
+            gap: var(--cpd-space-3x);
+            padding-top: var(--cpd-space-2x);
+            border-top: 1px solid var(--cpd-color-border-interactive-secondary);
         }
 
         button {
             flex: 1;
-            padding: var(--space-md) var(--space-lg);
+            padding: var(--cpd-space-3x) var(--cpd-space-4x);
             border: none;
             border-radius: var(--radius-md);
-            font-size: 14px;
-            font-weight: 500;
+            font: var(--cpd-font-body-md-medium);
             cursor: pointer;
             transition: background var(--transition-fast), opacity var(--transition-fast);
             outline: none;
         }
 
         button:focus-visible {
-            box-shadow: 0 0 0 2px var(--color-focus-ring);
+            box-shadow: 0 0 0 2px var(--cpd-color-border-focused);
         }
 
         button:disabled {
@@ -231,21 +198,21 @@ Please see LICENSE files in the repository root for full details.
         }
 
         .btn-primary {
-            background: var(--color-accent);
-            color: white;
+            background: var(--cpd-color-bg-accent-rest);
+            color: var(--cpd-color-text-on-solid-primary);
         }
 
         .btn-primary:hover:not(:disabled) {
-            background: var(--color-accent-hover);
+            background: var(--cpd-color-bg-accent-hovered);
         }
 
         .btn-secondary {
-            background: var(--color-bg-button-secondary);
-            color: white;
+            background: var(--cpd-color-bg-action-secondary-rest);
+            color: var(--cpd-color-text-primary);
         }
 
         .btn-secondary:hover:not(:disabled) {
-            background: var(--color-bg-button-secondary-hover);
+            background: var(--cpd-color-bg-action-secondary-hovered);
         }
 
         .loading {
@@ -253,16 +220,16 @@ Please see LICENSE files in the repository root for full details.
             flex-direction: column;
             align-items: center;
             justify-content: center;
-            padding: 40px;
-            color: var(--color-text-muted);
-            gap: var(--space-md);
+            padding: var(--cpd-space-10x);
+            color: var(--cpd-color-text-disabled);
+            gap: var(--cpd-space-3x);
         }
 
         .spinner {
-            width: 24px;
-            height: 24px;
-            border: 2px solid var(--color-border-subtle);
-            border-top-color: var(--color-accent);
+            width: var(--cpd-space-6x);
+            height: var(--cpd-space-6x);
+            border: 2px solid var(--cpd-color-border-interactive-secondary);
+            border-top-color: var(--cpd-color-bg-accent-rest);
             border-radius: 50%;
             animation: spin 0.8s linear infinite;
         }
@@ -270,8 +237,8 @@ Please see LICENSE files in the repository root for full details.
         @media (prefers-reduced-motion: reduce) {
             .spinner {
                 animation: none;
-                border-top-color: var(--color-border-subtle);
-                border-right-color: var(--color-accent);
+                border-top-color: var(--cpd-color-border-interactive-secondary);
+                border-right-color: var(--cpd-color-bg-accent-rest);
             }
         }
 
@@ -280,19 +247,19 @@ Please see LICENSE files in the repository root for full details.
         }
 
         .error {
-            background: var(--color-bg-error);
-            border: 1px solid var(--color-border-error);
-            color: var(--color-text-error);
-            padding: var(--space-lg);
+            background: var(--cpd-color-bg-critical-subtle);
+            border: 1px solid var(--cpd-color-border-critical-subtle);
+            color: var(--cpd-color-text-critical-primary);
+            padding: var(--cpd-space-4x);
             border-radius: var(--radius-md);
-            margin-bottom: var(--space-lg);
+            margin-bottom: var(--cpd-space-4x);
         }
 
         .no-apps {
             text-align: center;
-            padding: var(--space-xl);
-            color: var(--color-text-muted);
-            font-size: 13px;
+            padding: var(--cpd-space-5x);
+            color: var(--cpd-color-text-disabled);
+            font: var(--cpd-font-body-sm-regular);
         }
     </style>
 </head>
@@ -520,8 +487,13 @@ Please see LICENSE files in the repository root for full details.
                 }
             });
 
-            // Load translated strings, then sources
-            window.audioPickerAPI.getStrings()
+            // Load config (theme) first, then strings, then sources
+            window.audioPickerAPI.getConfig()
+                .then(function(config) {
+                    // Apply Compound theme class immediately for correct token values
+                    document.documentElement.classList.add("cpd-theme-" + (config.theme || "dark"));
+                    return window.audioPickerAPI.getStrings();
+                })
                 .then(function(s) {
                     strings = s;
 

--- a/build/audio-picker.html
+++ b/build/audio-picker.html
@@ -10,28 +10,29 @@ Please see LICENSE files in the repository root for full details.
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';">
-    <title>Share Audio</title>
+    <title id="page-title">Share Audio</title>
     <style>
         :root {
-            /* Element/Compound-aligned color tokens */
-            --color-bg-canvas: #15191e;
-            --color-bg-subtle: #21262d;
-            --color-bg-subtle-hover: #282e36;
-            --color-bg-accent: rgba(13, 189, 139, 0.15);
-            --color-border-accent: #0dbd8b;
-            --color-accent: #0dbd8b;
-            --color-accent-hover: #0aa87c;
-            --color-text-primary: #ffffff;
-            --color-text-secondary: #a9b2bc;
-            --color-text-muted: #8d99a5;
-            --color-border-subtle: #30363d;
-            --color-border-interactive: #6e7681;
-            --color-bg-button-secondary: #30363d;
-            --color-bg-button-secondary-hover: #3d444d;
-            --color-bg-error: rgba(255, 75, 85, 0.15);
-            --color-border-error: rgba(255, 75, 85, 0.4);
-            --color-text-error: #ff4b55;
-            --color-focus-ring: rgba(13, 189, 139, 0.4);
+            /* Compound Design Tokens — dark theme resolved values
+             * from @vector-im/compound-design-tokens */
+            --color-bg-canvas: var(--cpd-color-bg-canvas-default, #101317);
+            --color-bg-subtle: var(--cpd-color-bg-subtle-primary, #26282d);
+            --color-bg-subtle-hover: var(--cpd-color-bg-action-secondary-hovered, hsla(286, 31%, 82%, 0.04));
+            --color-bg-accent: var(--cpd-color-bg-accent-selected, hsl(151, 100%, 7%));
+            --color-border-accent: var(--cpd-color-border-accent-subtle, #005a43);
+            --color-accent: var(--cpd-color-bg-accent-rest, #129a78);
+            --color-accent-hover: var(--cpd-color-bg-accent-hovered, #17ac84);
+            --color-text-primary: var(--cpd-color-text-primary, #ebeef2);
+            --color-text-secondary: var(--cpd-color-text-secondary, #808994);
+            --color-text-muted: var(--cpd-color-text-disabled, #656c76);
+            --color-border-subtle: var(--cpd-color-border-interactive-secondary, #3c3f44);
+            --color-border-interactive: var(--cpd-color-border-interactive-primary, #656c76);
+            --color-bg-button-secondary: var(--cpd-color-bg-action-secondary-rest, #101317);
+            --color-bg-button-secondary-hover: var(--cpd-color-bg-action-secondary-hovered, hsla(286, 31%, 82%, 0.04));
+            --color-bg-error: var(--cpd-color-bg-critical-subtle, #3e0000);
+            --color-border-error: var(--cpd-color-border-critical-subtle, #710000);
+            --color-text-error: var(--cpd-color-text-critical-primary, #fd3e3c);
+            --color-focus-ring: var(--cpd-color-border-focused, #4187eb);
 
             /* Spacing scale */
             --space-xs: 4px;
@@ -60,7 +61,7 @@ Please see LICENSE files in the repository root for full details.
         }
 
         body {
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+            font-family: var(--cpd-font-family-sans, Inter), "Helvetica Neue", "Segoe UI", Roboto, Ubuntu, "Fira Sans", "Noto Sans", Arial, sans-serif;
             background: var(--color-bg-canvas);
             color: var(--color-text-primary);
             padding: var(--space-xl);
@@ -297,18 +298,18 @@ Please see LICENSE files in the repository root for full details.
 </head>
 <body>
     <main>
-        <h1>Share Audio</h1>
-        <p class="subtitle">Choose what audio to share with the call</p>
+        <h1 id="heading"></h1>
+        <p class="subtitle" id="subtitle"></p>
 
         <div id="content" class="loading" aria-live="polite">
             <div class="spinner" aria-hidden="true"></div>
-            <span>Loading audio sources...</span>
+            <span id="loading-text"></span>
         </div>
     </main>
 
     <div class="buttons">
-        <button type="button" class="btn-secondary" id="cancel">Cancel</button>
-        <button type="button" class="btn-primary" id="share" disabled>Share</button>
+        <button type="button" class="btn-secondary" id="cancel"></button>
+        <button type="button" class="btn-primary" id="share" disabled></button>
     </div>
 
     <script>
@@ -318,6 +319,9 @@ Please see LICENSE files in the repository root for full details.
             const content = document.getElementById("content");
             const shareBtn = document.getElementById("share");
             const cancelBtn = document.getElementById("cancel");
+
+            /** @type {Record<string, string>} */
+            var strings = {};
 
             let selectedType = "none";
             let selectedNode = null;
@@ -423,26 +427,26 @@ Please see LICENSE files in the repository root for full details.
                 const apps = Array.from(appMap.entries())
                     .sort(function(a, b) { return a[0].localeCompare(b[0]); });
 
-                let html = '<div role="radiogroup" aria-label="Audio source selection">';
+                let html = '<div role="radiogroup" aria-label="' + escapeHtml(strings.title) + '">';
 
                 html += '\
                     <div class="option" role="radio" aria-checked="true" tabindex="0" data-type="none">\
                         <div class="option-radio" aria-hidden="true"></div>\
                         <div class="option-content">\
-                            <div class="option-label">No audio</div>\
-                            <div class="option-description">Share screen only</div>\
+                            <div class="option-label">' + escapeHtml(strings.noAudioLabel) + '</div>\
+                            <div class="option-description">' + escapeHtml(strings.noAudioDescription) + '</div>\
                         </div>\
                     </div>\
                     <div class="option" role="radio" aria-checked="false" tabindex="-1" data-type="system">\
                         <div class="option-radio" aria-hidden="true"></div>\
                         <div class="option-content">\
-                            <div class="option-label">Entire system</div>\
-                            <div class="option-description">Share all audio from your computer</div>\
+                            <div class="option-label">' + escapeHtml(strings.systemLabel) + '</div>\
+                            <div class="option-description">' + escapeHtml(strings.systemDescription) + '</div>\
                         </div>\
                     </div>';
 
                 if (apps.length > 0) {
-                    html += '<div class="section-header">Applications</div><div class="app-list">';
+                    html += '<div class="section-header">' + escapeHtml(strings.applicationsHeader) + '</div><div class="app-list">';
                     for (const [name, node] of apps) {
                         const nodeJson = JSON.stringify(node).replace(/"/g, "&quot;");
                         html += '\
@@ -455,7 +459,7 @@ Please see LICENSE files in the repository root for full details.
                     }
                     html += '</div>';
                 } else {
-                    html += '<div class="no-apps">No applications are currently playing audio</div>';
+                    html += '<div class="no-apps">' + escapeHtml(strings.noApps) + '</div>';
                 }
 
                 html += '</div>';
@@ -516,23 +520,36 @@ Please see LICENSE files in the repository root for full details.
                 }
             });
 
-            // Load sources
-            window.audioPickerAPI.getSources()
+            // Load translated strings, then sources
+            window.audioPickerAPI.getStrings()
+                .then(function(s) {
+                    strings = s;
+
+                    // Populate static UI elements with translated strings
+                    document.getElementById("page-title").textContent = strings.title;
+                    document.getElementById("heading").textContent = strings.title;
+                    document.getElementById("subtitle").textContent = strings.subtitle;
+                    document.getElementById("loading-text").textContent = strings.loading;
+                    cancelBtn.textContent = strings.cancel;
+                    shareBtn.textContent = strings.share;
+
+                    return window.audioPickerAPI.getSources();
+                })
                 .then(function(sources) {
                     if (sources.ok) {
                         renderOptions(sources);
                     } else {
                         content.className = "";
-                        content.innerHTML = '<div class="error">\
-                            Unable to load audio sources. ' +
-                            (sources.isGlibcOutdated ? "Your system's GLIBC version may be too old." : "PipeWire may not be available.") +
+                        content.innerHTML = '<div class="error">' +
+                            escapeHtml(strings.errorLoadPrefix) + ' ' +
+                            (sources.isGlibcOutdated ? escapeHtml(strings.errorGlibc) : escapeHtml(strings.errorPipewire)) +
                         '</div>';
                         shareBtn.disabled = false;
                     }
                 })
                 .catch(function(err) {
                     content.className = "";
-                    content.innerHTML = '<div class="error">Failed to load audio sources: ' + escapeHtml(err.message) + '</div>';
+                    content.innerHTML = '<div class="error">' + escapeHtml((strings.errorLoadPrefix || "Failed to load audio sources:") + " " + err.message) + '</div>';
                     shareBtn.disabled = false;
                 });
         })();

--- a/build/audio-picker.html
+++ b/build/audio-picker.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
-Copyright 2025 New Vector Ltd.
+Copyright 2026 Joao Costa <me@joaocosta.dev>
 
 SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
 Please see LICENSE files in the repository root for full details.

--- a/build/audio-picker.html
+++ b/build/audio-picker.html
@@ -1,0 +1,341 @@
+<!DOCTYPE html>
+<!--
+Copyright 2025 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+-->
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';">
+    <title>Share Audio</title>
+    <style>
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+            background: #15191e;
+            color: #ffffff;
+            padding: 20px;
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+        }
+
+        h1 {
+            font-size: 18px;
+            font-weight: 600;
+            margin-bottom: 8px;
+        }
+
+        .subtitle {
+            font-size: 13px;
+            color: #8d99a5;
+            margin-bottom: 20px;
+        }
+
+        .options-container {
+            flex: 1;
+            overflow-y: auto;
+            margin-bottom: 16px;
+        }
+
+        .option {
+            display: flex;
+            align-items: center;
+            padding: 14px 16px;
+            border-radius: 8px;
+            margin-bottom: 8px;
+            cursor: pointer;
+            background: #21262d;
+            border: 2px solid transparent;
+            transition: all 0.15s ease;
+        }
+
+        .option:hover {
+            background: #282e36;
+        }
+
+        .option.selected {
+            background: rgba(13, 110, 253, 0.15);
+            border-color: #0d6efd;
+        }
+
+        .option input[type="radio"] {
+            display: none;
+        }
+
+        .option-radio {
+            width: 18px;
+            height: 18px;
+            border: 2px solid #6e7681;
+            border-radius: 50%;
+            margin-right: 14px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            flex-shrink: 0;
+        }
+
+        .option.selected .option-radio {
+            border-color: #0d6efd;
+        }
+
+        .option.selected .option-radio::after {
+            content: "";
+            width: 10px;
+            height: 10px;
+            border-radius: 50%;
+            background: #0d6efd;
+        }
+
+        .option-content {
+            flex: 1;
+            min-width: 0;
+        }
+
+        .option-label {
+            font-size: 14px;
+            font-weight: 500;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .option-description {
+            font-size: 12px;
+            color: #8d99a5;
+            margin-top: 2px;
+        }
+
+        .section-header {
+            font-size: 12px;
+            font-weight: 600;
+            color: #8d99a5;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            margin: 20px 0 12px;
+        }
+
+        .app-list {
+            max-height: 240px;
+            overflow-y: auto;
+            border-radius: 8px;
+        }
+
+        .buttons {
+            display: flex;
+            gap: 12px;
+            padding-top: 8px;
+            border-top: 1px solid #30363d;
+        }
+
+        button {
+            flex: 1;
+            padding: 12px 16px;
+            border: none;
+            border-radius: 8px;
+            font-size: 14px;
+            font-weight: 500;
+            cursor: pointer;
+            transition: all 0.15s ease;
+        }
+
+        .btn-primary {
+            background: #0d6efd;
+            color: white;
+        }
+
+        .btn-primary:hover {
+            background: #0b5ed7;
+        }
+
+        .btn-secondary {
+            background: #30363d;
+            color: white;
+        }
+
+        .btn-secondary:hover {
+            background: #3d444d;
+        }
+
+        .loading {
+            text-align: center;
+            padding: 40px;
+            color: #8d99a5;
+        }
+
+        .error {
+            background: rgba(220, 53, 69, 0.15);
+            border: 1px solid rgba(220, 53, 69, 0.4);
+            color: #f8d7da;
+            padding: 16px;
+            border-radius: 8px;
+            margin-bottom: 16px;
+        }
+
+        .no-apps {
+            text-align: center;
+            padding: 20px;
+            color: #6e7681;
+            font-size: 13px;
+        }
+    </style>
+</head>
+<body>
+    <h1>Share Audio</h1>
+    <p class="subtitle">Choose what audio to share with the call</p>
+
+    <div id="content" class="loading">Loading audio sources...</div>
+
+    <div class="buttons">
+        <button class="btn-secondary" id="cancel">Cancel</button>
+        <button class="btn-primary" id="share">Share</button>
+    </div>
+
+    <script>
+        (function() {
+            const content = document.getElementById("content");
+            const shareBtn = document.getElementById("share");
+            const cancelBtn = document.getElementById("cancel");
+
+            let selectedType = "none";
+            let selectedNode = null;
+
+            function getAppName(node) {
+                return node["application.name"] || 
+                       node["application.process.binary"] || 
+                       node["node.name"] || 
+                       "Unknown Application";
+            }
+
+            function renderOptions(sources) {
+                const targets = sources.targets || [];
+                
+                // Group by application name to avoid duplicates
+                // Only store stable properties that won't change when the app recreates its audio node
+                const appMap = new Map();
+                for (const node of targets) {
+                    const name = getAppName(node);
+                    if (!appMap.has(name)) {
+                        // Create a minimal filter using only stable properties
+                        // This ensures venmic can re-link if the app recreates its audio node
+                        const stableNode = {};
+                        if (node["application.name"]) {
+                            stableNode["application.name"] = node["application.name"];
+                        } else if (node["node.name"]) {
+                            stableNode["node.name"] = node["node.name"];
+                        }
+                        appMap.set(name, stableNode);
+                    }
+                }
+
+                const apps = Array.from(appMap.entries())
+                    .sort((a, b) => a[0].localeCompare(b[0]));
+
+                let html = `
+                    <div class="option selected" data-type="none">
+                        <div class="option-radio"></div>
+                        <div class="option-content">
+                            <div class="option-label">No audio</div>
+                            <div class="option-description">Share screen only</div>
+                        </div>
+                    </div>
+
+                    <div class="option" data-type="system">
+                        <div class="option-radio"></div>
+                        <div class="option-content">
+                            <div class="option-label">Entire system</div>
+                            <div class="option-description">Share all audio from your computer</div>
+                        </div>
+                    </div>
+                `;
+
+                if (apps.length > 0) {
+                    html += `<div class="section-header">Applications</div><div class="app-list">`;
+                    for (const [name, node] of apps) {
+                        const nodeJson = JSON.stringify(node).replace(/"/g, "&quot;");
+                        html += `
+                            <div class="option" data-type="app" data-node="${nodeJson}">
+                                <div class="option-radio"></div>
+                                <div class="option-content">
+                                    <div class="option-label">${escapeHtml(name)}</div>
+                                </div>
+                            </div>
+                        `;
+                    }
+                    html += `</div>`;
+                } else {
+                    html += `<div class="no-apps">No applications are currently playing audio</div>`;
+                }
+
+                content.className = "options-container";
+                content.innerHTML = html;
+
+                // Add click handlers
+                content.querySelectorAll(".option").forEach(option => {
+                    option.addEventListener("click", () => {
+                        content.querySelectorAll(".option").forEach(o => o.classList.remove("selected"));
+                        option.classList.add("selected");
+                        selectedType = option.dataset.type;
+                        selectedNode = option.dataset.node ? JSON.parse(option.dataset.node) : null;
+                    });
+                });
+            }
+
+            function escapeHtml(text) {
+                const div = document.createElement("div");
+                div.textContent = text;
+                return div.innerHTML;
+            }
+
+            function submit() {
+                const selection = { type: selectedType };
+                if (selectedNode) {
+                    selection.node = selectedNode;
+                }
+                window.audioPickerAPI.submitSelection(selection);
+            }
+
+            shareBtn.addEventListener("click", submit);
+            cancelBtn.addEventListener("click", () => window.audioPickerAPI.cancel());
+
+            // Handle Enter key
+            document.addEventListener("keydown", (e) => {
+                if (e.key === "Enter") {
+                    submit();
+                } else if (e.key === "Escape") {
+                    window.audioPickerAPI.cancel();
+                }
+            });
+
+            // Load sources
+            console.log("audio-picker: calling getSources()");
+            window.audioPickerAPI.getSources()
+                .then(sources => {
+                    console.log("audio-picker: got sources", sources);
+                    if (sources.ok) {
+                        renderOptions(sources);
+                    } else {
+                        content.className = "";
+                        content.innerHTML = `<div class="error">
+                            Unable to load audio sources. 
+                            ${sources.isGlibCxxOutdated ? "Your system's GLIBC version may be too old." : "PipeWire may not be available."}
+                        </div>`;
+                    }
+                })
+                .catch(err => {
+                    console.error("audio-picker: error loading sources", err);
+                    content.className = "";
+                    content.innerHTML = `<div class="error">Failed to load audio sources: ${escapeHtml(err.message)}</div>`;
+                });
+        })();
+    </script>
+</body>
+</html>

--- a/build/audio-picker.html
+++ b/build/audio-picker.html
@@ -12,6 +12,47 @@ Please see LICENSE files in the repository root for full details.
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';">
     <title>Share Audio</title>
     <style>
+        :root {
+            /* Element/Compound-aligned color tokens */
+            --color-bg-canvas: #15191e;
+            --color-bg-subtle: #21262d;
+            --color-bg-subtle-hover: #282e36;
+            --color-bg-accent: rgba(13, 189, 139, 0.15);
+            --color-border-accent: #0dbd8b;
+            --color-accent: #0dbd8b;
+            --color-accent-hover: #0aa87c;
+            --color-text-primary: #ffffff;
+            --color-text-secondary: #a9b2bc;
+            --color-text-muted: #8d99a5;
+            --color-border-subtle: #30363d;
+            --color-border-interactive: #6e7681;
+            --color-bg-button-secondary: #30363d;
+            --color-bg-button-secondary-hover: #3d444d;
+            --color-bg-error: rgba(255, 75, 85, 0.15);
+            --color-border-error: rgba(255, 75, 85, 0.4);
+            --color-text-error: #ff4b55;
+            --color-focus-ring: rgba(13, 189, 139, 0.4);
+
+            /* Spacing scale */
+            --space-xs: 4px;
+            --space-sm: 8px;
+            --space-md: 12px;
+            --space-lg: 16px;
+            --space-xl: 20px;
+
+            /* Border radius */
+            --radius-md: 8px;
+
+            /* Transitions */
+            --transition-fast: 0.15s ease;
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            :root {
+                --transition-fast: 0s;
+            }
+        }
+
         * {
             box-sizing: border-box;
             margin: 0;
@@ -20,79 +61,110 @@ Please see LICENSE files in the repository root for full details.
 
         body {
             font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-            background: #15191e;
-            color: #ffffff;
-            padding: 20px;
+            background: var(--color-bg-canvas);
+            color: var(--color-text-primary);
+            padding: var(--space-xl);
             min-height: 100vh;
             display: flex;
             flex-direction: column;
         }
 
+        main {
+            display: flex;
+            flex-direction: column;
+            flex: 1;
+            min-height: 0;
+        }
+
         h1 {
             font-size: 18px;
             font-weight: 600;
-            margin-bottom: 8px;
+            margin-bottom: var(--space-sm);
         }
 
         .subtitle {
             font-size: 13px;
-            color: #8d99a5;
-            margin-bottom: 20px;
+            color: var(--color-text-secondary);
+            margin-bottom: var(--space-xl);
         }
 
         .options-container {
             flex: 1;
             overflow-y: auto;
-            margin-bottom: 16px;
+            margin-bottom: var(--space-lg);
+        }
+
+        /* Scrollbar styling */
+        .options-container::-webkit-scrollbar,
+        .app-list::-webkit-scrollbar {
+            width: 6px;
+        }
+
+        .options-container::-webkit-scrollbar-track,
+        .app-list::-webkit-scrollbar-track {
+            background: transparent;
+        }
+
+        .options-container::-webkit-scrollbar-thumb,
+        .app-list::-webkit-scrollbar-thumb {
+            background: var(--color-border-subtle);
+            border-radius: 3px;
+        }
+
+        .options-container::-webkit-scrollbar-thumb:hover,
+        .app-list::-webkit-scrollbar-thumb:hover {
+            background: var(--color-border-interactive);
         }
 
         .option {
             display: flex;
             align-items: center;
-            padding: 14px 16px;
-            border-radius: 8px;
-            margin-bottom: 8px;
+            padding: 14px var(--space-lg);
+            border-radius: var(--radius-md);
+            margin-bottom: var(--space-sm);
             cursor: pointer;
-            background: #21262d;
+            background: var(--color-bg-subtle);
             border: 2px solid transparent;
-            transition: all 0.15s ease;
+            transition: background var(--transition-fast), border-color var(--transition-fast);
+            outline: none;
         }
 
         .option:hover {
-            background: #282e36;
+            background: var(--color-bg-subtle-hover);
         }
 
-        .option.selected {
-            background: rgba(13, 110, 253, 0.15);
-            border-color: #0d6efd;
+        .option:focus-visible {
+            box-shadow: 0 0 0 2px var(--color-focus-ring);
         }
 
-        .option input[type="radio"] {
-            display: none;
+        .option[aria-checked="true"] {
+            background: var(--color-bg-accent);
+            border-color: var(--color-border-accent);
         }
 
         .option-radio {
             width: 18px;
             height: 18px;
-            border: 2px solid #6e7681;
+            border: 2px solid var(--color-border-interactive);
             border-radius: 50%;
             margin-right: 14px;
             display: flex;
             align-items: center;
             justify-content: center;
             flex-shrink: 0;
+            transition: border-color var(--transition-fast);
         }
 
-        .option.selected .option-radio {
-            border-color: #0d6efd;
+        .option[aria-checked="true"] .option-radio {
+            border-color: var(--color-border-accent);
         }
 
-        .option.selected .option-radio::after {
+        .option[aria-checked="true"] .option-radio::after {
             content: "";
             width: 10px;
             height: 10px;
             border-radius: 50%;
-            background: #0d6efd;
+            background: var(--color-accent);
         }
 
         .option-content {
@@ -110,114 +182,226 @@ Please see LICENSE files in the repository root for full details.
 
         .option-description {
             font-size: 12px;
-            color: #8d99a5;
+            color: var(--color-text-secondary);
             margin-top: 2px;
         }
 
         .section-header {
             font-size: 12px;
             font-weight: 600;
-            color: #8d99a5;
+            color: var(--color-text-secondary);
             text-transform: uppercase;
             letter-spacing: 0.5px;
-            margin: 20px 0 12px;
+            margin: var(--space-xl) 0 var(--space-md);
         }
 
         .app-list {
             max-height: 240px;
             overflow-y: auto;
-            border-radius: 8px;
+            border-radius: var(--radius-md);
         }
 
         .buttons {
             display: flex;
-            gap: 12px;
-            padding-top: 8px;
-            border-top: 1px solid #30363d;
+            gap: var(--space-md);
+            padding-top: var(--space-sm);
+            border-top: 1px solid var(--color-border-subtle);
         }
 
         button {
             flex: 1;
-            padding: 12px 16px;
+            padding: var(--space-md) var(--space-lg);
             border: none;
-            border-radius: 8px;
+            border-radius: var(--radius-md);
             font-size: 14px;
             font-weight: 500;
             cursor: pointer;
-            transition: all 0.15s ease;
+            transition: background var(--transition-fast), opacity var(--transition-fast);
+            outline: none;
+        }
+
+        button:focus-visible {
+            box-shadow: 0 0 0 2px var(--color-focus-ring);
+        }
+
+        button:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
         }
 
         .btn-primary {
-            background: #0d6efd;
+            background: var(--color-accent);
             color: white;
         }
 
-        .btn-primary:hover {
-            background: #0b5ed7;
+        .btn-primary:hover:not(:disabled) {
+            background: var(--color-accent-hover);
         }
 
         .btn-secondary {
-            background: #30363d;
+            background: var(--color-bg-button-secondary);
             color: white;
         }
 
-        .btn-secondary:hover {
-            background: #3d444d;
+        .btn-secondary:hover:not(:disabled) {
+            background: var(--color-bg-button-secondary-hover);
         }
 
         .loading {
-            text-align: center;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
             padding: 40px;
-            color: #8d99a5;
+            color: var(--color-text-muted);
+            gap: var(--space-md);
+        }
+
+        .spinner {
+            width: 24px;
+            height: 24px;
+            border: 2px solid var(--color-border-subtle);
+            border-top-color: var(--color-accent);
+            border-radius: 50%;
+            animation: spin 0.8s linear infinite;
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            .spinner {
+                animation: none;
+                border-top-color: var(--color-border-subtle);
+                border-right-color: var(--color-accent);
+            }
+        }
+
+        @keyframes spin {
+            to { transform: rotate(360deg); }
         }
 
         .error {
-            background: rgba(220, 53, 69, 0.15);
-            border: 1px solid rgba(220, 53, 69, 0.4);
-            color: #f8d7da;
-            padding: 16px;
-            border-radius: 8px;
-            margin-bottom: 16px;
+            background: var(--color-bg-error);
+            border: 1px solid var(--color-border-error);
+            color: var(--color-text-error);
+            padding: var(--space-lg);
+            border-radius: var(--radius-md);
+            margin-bottom: var(--space-lg);
         }
 
         .no-apps {
             text-align: center;
-            padding: 20px;
-            color: #6e7681;
+            padding: var(--space-xl);
+            color: var(--color-text-muted);
             font-size: 13px;
         }
     </style>
 </head>
 <body>
-    <h1>Share Audio</h1>
-    <p class="subtitle">Choose what audio to share with the call</p>
+    <main>
+        <h1>Share Audio</h1>
+        <p class="subtitle">Choose what audio to share with the call</p>
 
-    <div id="content" class="loading">Loading audio sources...</div>
+        <div id="content" class="loading" aria-live="polite">
+            <div class="spinner" aria-hidden="true"></div>
+            <span>Loading audio sources...</span>
+        </div>
+    </main>
 
     <div class="buttons">
-        <button class="btn-secondary" id="cancel">Cancel</button>
-        <button class="btn-primary" id="share">Share</button>
+        <button type="button" class="btn-secondary" id="cancel">Cancel</button>
+        <button type="button" class="btn-primary" id="share" disabled>Share</button>
     </div>
 
     <script>
         (function() {
+            "use strict";
+
             const content = document.getElementById("content");
             const shareBtn = document.getElementById("share");
             const cancelBtn = document.getElementById("cancel");
 
             let selectedType = "none";
             let selectedNode = null;
+            let isSubmitting = false;
 
             function getAppName(node) {
-                return node["application.name"] || 
-                       node["application.process.binary"] || 
-                       node["node.name"] || 
+                return node["application.name"] ||
+                       node["application.process.binary"] ||
+                       node["node.name"] ||
                        "Unknown Application";
+            }
+
+            function escapeHtml(text) {
+                const div = document.createElement("div");
+                div.textContent = text;
+                return div.innerHTML;
+            }
+
+            function selectOption(option) {
+                // Update visual state
+                content.querySelectorAll(".option").forEach(function(o) {
+                    o.setAttribute("aria-checked", "false");
+                    o.setAttribute("tabindex", "-1");
+                });
+                option.setAttribute("aria-checked", "true");
+                option.setAttribute("tabindex", "0");
+                option.focus();
+
+                // Update selection state
+                selectedType = option.dataset.type;
+                if (option.dataset.node) {
+                    try {
+                        selectedNode = JSON.parse(option.dataset.node);
+                    } catch (e) {
+                        selectedNode = null;
+                    }
+                } else {
+                    selectedNode = null;
+                }
+            }
+
+            function handleKeyDown(e) {
+                const options = Array.from(content.querySelectorAll(".option"));
+                const currentIndex = options.findIndex(function(o) {
+                    return o.getAttribute("aria-checked") === "true";
+                });
+
+                let nextIndex = currentIndex;
+
+                switch (e.key) {
+                    case "ArrowDown":
+                    case "ArrowRight":
+                        e.preventDefault();
+                        nextIndex = (currentIndex + 1) % options.length;
+                        break;
+                    case "ArrowUp":
+                    case "ArrowLeft":
+                        e.preventDefault();
+                        nextIndex = (currentIndex - 1 + options.length) % options.length;
+                        break;
+                    case "Home":
+                        e.preventDefault();
+                        nextIndex = 0;
+                        break;
+                    case "End":
+                        e.preventDefault();
+                        nextIndex = options.length - 1;
+                        break;
+                    case " ":
+                        e.preventDefault();
+                        // Space confirms current selection (already selected via focus)
+                        return;
+                    default:
+                        return;
+                }
+
+                if (nextIndex !== currentIndex && options[nextIndex]) {
+                    selectOption(options[nextIndex]);
+                }
             }
 
             function renderOptions(sources) {
                 const targets = sources.targets || [];
-                
+
                 // Group by application name to avoid duplicates
                 // Only store stable properties that won't change when the app recreates its audio node
                 const appMap = new Map();
@@ -237,65 +421,74 @@ Please see LICENSE files in the repository root for full details.
                 }
 
                 const apps = Array.from(appMap.entries())
-                    .sort((a, b) => a[0].localeCompare(b[0]));
+                    .sort(function(a, b) { return a[0].localeCompare(b[0]); });
 
-                let html = `
-                    <div class="option selected" data-type="none">
-                        <div class="option-radio"></div>
-                        <div class="option-content">
-                            <div class="option-label">No audio</div>
-                            <div class="option-description">Share screen only</div>
-                        </div>
-                    </div>
+                let html = '<div role="radiogroup" aria-label="Audio source selection">';
 
-                    <div class="option" data-type="system">
-                        <div class="option-radio"></div>
-                        <div class="option-content">
-                            <div class="option-label">Entire system</div>
-                            <div class="option-description">Share all audio from your computer</div>
-                        </div>
-                    </div>
-                `;
+                html += '\
+                    <div class="option" role="radio" aria-checked="true" tabindex="0" data-type="none">\
+                        <div class="option-radio" aria-hidden="true"></div>\
+                        <div class="option-content">\
+                            <div class="option-label">No audio</div>\
+                            <div class="option-description">Share screen only</div>\
+                        </div>\
+                    </div>\
+                    <div class="option" role="radio" aria-checked="false" tabindex="-1" data-type="system">\
+                        <div class="option-radio" aria-hidden="true"></div>\
+                        <div class="option-content">\
+                            <div class="option-label">Entire system</div>\
+                            <div class="option-description">Share all audio from your computer</div>\
+                        </div>\
+                    </div>';
 
                 if (apps.length > 0) {
-                    html += `<div class="section-header">Applications</div><div class="app-list">`;
+                    html += '<div class="section-header">Applications</div><div class="app-list">';
                     for (const [name, node] of apps) {
                         const nodeJson = JSON.stringify(node).replace(/"/g, "&quot;");
-                        html += `
-                            <div class="option" data-type="app" data-node="${nodeJson}">
-                                <div class="option-radio"></div>
-                                <div class="option-content">
-                                    <div class="option-label">${escapeHtml(name)}</div>
-                                </div>
-                            </div>
-                        `;
+                        html += '\
+                            <div class="option" role="radio" aria-checked="false" tabindex="-1" data-type="app" data-node="' + nodeJson + '">\
+                                <div class="option-radio" aria-hidden="true"></div>\
+                                <div class="option-content">\
+                                    <div class="option-label">' + escapeHtml(name) + '</div>\
+                                </div>\
+                            </div>';
                     }
-                    html += `</div>`;
+                    html += '</div>';
                 } else {
-                    html += `<div class="no-apps">No applications are currently playing audio</div>`;
+                    html += '<div class="no-apps">No applications are currently playing audio</div>';
                 }
+
+                html += '</div>';
 
                 content.className = "options-container";
                 content.innerHTML = html;
 
                 // Add click handlers
-                content.querySelectorAll(".option").forEach(option => {
-                    option.addEventListener("click", () => {
-                        content.querySelectorAll(".option").forEach(o => o.classList.remove("selected"));
-                        option.classList.add("selected");
-                        selectedType = option.dataset.type;
-                        selectedNode = option.dataset.node ? JSON.parse(option.dataset.node) : null;
+                content.querySelectorAll(".option").forEach(function(option) {
+                    option.addEventListener("click", function() {
+                        selectOption(option);
                     });
                 });
-            }
 
-            function escapeHtml(text) {
-                const div = document.createElement("div");
-                div.textContent = text;
-                return div.innerHTML;
+                // Add keyboard navigation to radiogroup
+                const radiogroup = content.querySelector('[role="radiogroup"]');
+                if (radiogroup) {
+                    radiogroup.addEventListener("keydown", handleKeyDown);
+                }
+
+                // Enable share button and focus first option
+                shareBtn.disabled = false;
+                const firstOption = content.querySelector(".option");
+                if (firstOption) {
+                    firstOption.focus();
+                }
             }
 
             function submit() {
+                if (isSubmitting || shareBtn.disabled) return;
+                isSubmitting = true;
+                shareBtn.disabled = true;
+
                 const selection = { type: selectedType };
                 if (selectedNode) {
                     selection.node = selectedNode;
@@ -303,37 +496,44 @@ Please see LICENSE files in the repository root for full details.
                 window.audioPickerAPI.submitSelection(selection);
             }
 
-            shareBtn.addEventListener("click", submit);
-            cancelBtn.addEventListener("click", () => window.audioPickerAPI.cancel());
+            function cancel() {
+                if (isSubmitting) return;
+                isSubmitting = true;
+                window.audioPickerAPI.cancel();
+            }
 
-            // Handle Enter key
-            document.addEventListener("keydown", (e) => {
-                if (e.key === "Enter") {
+            shareBtn.addEventListener("click", submit);
+            cancelBtn.addEventListener("click", cancel);
+
+            // Handle global keyboard shortcuts
+            document.addEventListener("keydown", function(e) {
+                if (e.key === "Enter" && !shareBtn.disabled) {
+                    e.preventDefault();
                     submit();
                 } else if (e.key === "Escape") {
-                    window.audioPickerAPI.cancel();
+                    e.preventDefault();
+                    cancel();
                 }
             });
 
             // Load sources
-            console.log("audio-picker: calling getSources()");
             window.audioPickerAPI.getSources()
-                .then(sources => {
-                    console.log("audio-picker: got sources", sources);
+                .then(function(sources) {
                     if (sources.ok) {
                         renderOptions(sources);
                     } else {
                         content.className = "";
-                        content.innerHTML = `<div class="error">
-                            Unable to load audio sources. 
-                            ${sources.isGlibCxxOutdated ? "Your system's GLIBC version may be too old." : "PipeWire may not be available."}
-                        </div>`;
+                        content.innerHTML = '<div class="error">\
+                            Unable to load audio sources. ' +
+                            (sources.isGlibCxxOutdated ? "Your system's GLIBC version may be too old." : "PipeWire may not be available.") +
+                        '</div>';
+                        shareBtn.disabled = false;
                     }
                 })
-                .catch(err => {
-                    console.error("audio-picker: error loading sources", err);
+                .catch(function(err) {
                     content.className = "";
-                    content.innerHTML = `<div class="error">Failed to load audio sources: ${escapeHtml(err.message)}</div>`;
+                    content.innerHTML = '<div class="error">Failed to load audio sources: ' + escapeHtml(err.message) + '</div>';
+                    shareBtn.disabled = false;
                 });
         })();
     </script>

--- a/build/audio-picker.html
+++ b/build/audio-picker.html
@@ -525,7 +525,7 @@ Please see LICENSE files in the repository root for full details.
                         content.className = "";
                         content.innerHTML = '<div class="error">\
                             Unable to load audio sources. ' +
-                            (sources.isGlibCxxOutdated ? "Your system's GLIBC version may be too old." : "PipeWire may not be available.") +
+                            (sources.isGlibcOutdated ? "Your system's GLIBC version may be too old." : "PipeWire may not be available.") +
                         '</div>';
                         shareBtn.disabled = false;
                     }

--- a/electron-builder.ts
+++ b/electron-builder.ts
@@ -227,6 +227,17 @@ if (os.platform() === "linux") {
         // Remove sqlcipher dependency when using bundled
         config.deb.recommends = config.deb.recommends?.filter((d) => d !== "libsqlcipher0");
     }
+
+    // Include venmic native module prebuilds for Linux audio sharing.
+    // Only the .node files are needed since venmic.ts loads them directly.
+    config.files = [
+        ...(config.files as Array<string | object>),
+        {
+            from: "node_modules/@vencord/venmic",
+            to: "node_modules/@vencord/venmic",
+            filter: ["prebuilds/**/*.node"],
+        },
+    ];
 }
 
 export default config;

--- a/electron-builder.ts
+++ b/electron-builder.ts
@@ -118,7 +118,7 @@ const config: Omit<Writable<Configuration>, "electronFuses"> & {
         },
         "lib/**",
     ],
-    extraResources: ["build/icon.*", "build/audio-picker.html", "webapp.asar"],
+    extraResources: ["build/icon.*", "build/audio-picker.html", "build/compound/", "webapp.asar"],
     extraMetadata: {
         name: variant.name,
         productName: variant.productName,

--- a/electron-builder.ts
+++ b/electron-builder.ts
@@ -118,7 +118,7 @@ const config: Omit<Writable<Configuration>, "electronFuses"> & {
         },
         "lib/**",
     ],
-    extraResources: ["build/icon.*", "webapp.asar"],
+    extraResources: ["build/icon.*", "build/audio-picker.html", "webapp.asar"],
     extraMetadata: {
         name: variant.name,
         productName: variant.productName,

--- a/electron-builder.ts
+++ b/electron-builder.ts
@@ -227,17 +227,6 @@ if (os.platform() === "linux") {
         // Remove sqlcipher dependency when using bundled
         config.deb.recommends = config.deb.recommends?.filter((d) => d !== "libsqlcipher0");
     }
-
-    // Include venmic native module prebuilds for Linux audio sharing.
-    // Only the .node files are needed since venmic.ts loads them directly.
-    config.files = [
-        ...(config.files as Array<string | object>),
-        {
-            from: "node_modules/@vencord/venmic",
-            to: "node_modules/@vencord/venmic",
-            filter: ["prebuilds/**/*.node"],
-        },
-    ];
 }
 
 export default config;

--- a/hak/@vencord/venmic/build.ts
+++ b/hak/@vencord/venmic/build.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 New Vector Ltd.
+Copyright 2026 Joao Costa <me@joaocosta.dev>
 
 SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
 Please see LICENSE files in the repository root for full details.

--- a/hak/@vencord/venmic/build.ts
+++ b/hak/@vencord/venmic/build.ts
@@ -1,0 +1,54 @@
+/*
+Copyright 2026 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import path from "node:path";
+import fsProm from "node:fs/promises";
+
+import type HakEnv from "../../../scripts/hak/hakEnv.js";
+import type { DependencyInfo } from "../../../scripts/hak/dep.js";
+
+export default async function (hakEnv: HakEnv, moduleInfo: DependencyInfo): Promise<void> {
+  // venmic is Linux-only
+  if (!hakEnv.isLinux()) {
+    console.log("Skipping venmic build: not targeting Linux");
+    return;
+  }
+
+  const arch = hakEnv.getTargetArch();
+
+  // venmic only has x64 and arm64 prebuilds
+  if (arch !== "x64" && arch !== "arm64") {
+    console.log(`Skipping venmic build: no prebuild for architecture ${arch}`);
+    return;
+  }
+
+  const venmicSource = path.join(
+    hakEnv.projectRoot,
+    "node_modules",
+    "@vencord",
+    "venmic",
+    "prebuilds",
+    `venmic-addon-linux-${arch}`,
+    "node-napi-v7.node",
+  );
+
+  // Check if venmic is installed (it's optional)
+  try {
+    await fsProm.access(venmicSource);
+  } catch {
+    console.log("venmic prebuilds not found, skipping (optional dependency)");
+    return;
+  }
+
+  // Ensure build directory exists
+  await fsProm.mkdir(moduleInfo.moduleBuildDir, { recursive: true });
+
+  // Copy prebuild to build dir
+  const dest = path.join(moduleInfo.moduleBuildDir, "venmic.node");
+  await fsProm.copyFile(venmicSource, dest);
+  console.log(`Copied venmic ${arch} prebuild to ${dest}`);
+}

--- a/hak/@vencord/venmic/build.ts
+++ b/hak/@vencord/venmic/build.ts
@@ -12,43 +12,43 @@ import type HakEnv from "../../../scripts/hak/hakEnv.js";
 import type { DependencyInfo } from "../../../scripts/hak/dep.js";
 
 export default async function (hakEnv: HakEnv, moduleInfo: DependencyInfo): Promise<void> {
-  // venmic is Linux-only
-  if (!hakEnv.isLinux()) {
-    console.log("Skipping venmic build: not targeting Linux");
-    return;
-  }
+    // venmic is Linux-only
+    if (!hakEnv.isLinux()) {
+        console.log("Skipping venmic build: not targeting Linux");
+        return;
+    }
 
-  const arch = hakEnv.getTargetArch();
+    const arch = hakEnv.getTargetArch();
 
-  // venmic only has x64 and arm64 prebuilds
-  if (arch !== "x64" && arch !== "arm64") {
-    console.log(`Skipping venmic build: no prebuild for architecture ${arch}`);
-    return;
-  }
+    // venmic only has x64 and arm64 prebuilds
+    if (arch !== "x64" && arch !== "arm64") {
+        console.log(`Skipping venmic build: no prebuild for architecture ${arch}`);
+        return;
+    }
 
-  const venmicSource = path.join(
-    hakEnv.projectRoot,
-    "node_modules",
-    "@vencord",
-    "venmic",
-    "prebuilds",
-    `venmic-addon-linux-${arch}`,
-    "node-napi-v7.node",
-  );
+    const venmicSource = path.join(
+        hakEnv.projectRoot,
+        "node_modules",
+        "@vencord",
+        "venmic",
+        "prebuilds",
+        `venmic-addon-linux-${arch}`,
+        "node-napi-v7.node",
+    );
 
-  // Check if venmic is installed (it's optional)
-  try {
-    await fsProm.access(venmicSource);
-  } catch {
-    console.log("venmic prebuilds not found, skipping (optional dependency)");
-    return;
-  }
+    // Check if venmic is installed (it's optional)
+    try {
+        await fsProm.access(venmicSource);
+    } catch {
+        console.log("venmic prebuilds not found, skipping (optional dependency)");
+        return;
+    }
 
-  // Ensure build directory exists
-  await fsProm.mkdir(moduleInfo.moduleBuildDir, { recursive: true });
+    // Ensure build directory exists
+    await fsProm.mkdir(moduleInfo.moduleBuildDir, { recursive: true });
 
-  // Copy prebuild to build dir
-  const dest = path.join(moduleInfo.moduleBuildDir, "venmic.node");
-  await fsProm.copyFile(venmicSource, dest);
-  console.log(`Copied venmic ${arch} prebuild to ${dest}`);
+    // Copy prebuild to build dir
+    const dest = path.join(moduleInfo.moduleBuildDir, "venmic.node");
+    await fsProm.copyFile(venmicSource, dest);
+    console.log(`Copied venmic ${arch} prebuild to ${dest}`);
 }

--- a/hak/@vencord/venmic/check.ts
+++ b/hak/@vencord/venmic/check.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 New Vector Ltd.
+Copyright 2026 Joao Costa <me@joaocosta.dev>
 
 SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
 Please see LICENSE files in the repository root for full details.

--- a/hak/@vencord/venmic/check.ts
+++ b/hak/@vencord/venmic/check.ts
@@ -1,0 +1,23 @@
+/*
+Copyright 2026 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import type HakEnv from "../../../scripts/hak/hakEnv.js";
+import type { DependencyInfo } from "../../../scripts/hak/dep.js";
+
+export default async function (hakEnv: HakEnv, moduleInfo: DependencyInfo): Promise<void> {
+  // venmic is Linux-only
+  if (!hakEnv.isLinux()) {
+    console.log(`Skipping venmic: only supported on Linux (target: ${hakEnv.getTargetId()})`);
+    return;
+  }
+
+  // venmic only provides x64 and arm64 prebuilds
+  const arch = hakEnv.getTargetArch();
+  if (arch !== "x64" && arch !== "arm64") {
+    throw new Error(`venmic does not provide prebuilds for architecture: ${arch}`);
+  }
+}

--- a/hak/@vencord/venmic/check.ts
+++ b/hak/@vencord/venmic/check.ts
@@ -9,15 +9,15 @@ import type HakEnv from "../../../scripts/hak/hakEnv.js";
 import type { DependencyInfo } from "../../../scripts/hak/dep.js";
 
 export default async function (hakEnv: HakEnv, moduleInfo: DependencyInfo): Promise<void> {
-  // venmic is Linux-only
-  if (!hakEnv.isLinux()) {
-    console.log(`Skipping venmic: only supported on Linux (target: ${hakEnv.getTargetId()})`);
-    return;
-  }
+    // venmic is Linux-only
+    if (!hakEnv.isLinux()) {
+        console.log(`Skipping venmic: only supported on Linux (target: ${hakEnv.getTargetId()})`);
+        return;
+    }
 
-  // venmic only provides x64 and arm64 prebuilds
-  const arch = hakEnv.getTargetArch();
-  if (arch !== "x64" && arch !== "arm64") {
-    throw new Error(`venmic does not provide prebuilds for architecture: ${arch}`);
-  }
+    // venmic only provides x64 and arm64 prebuilds
+    const arch = hakEnv.getTargetArch();
+    if (arch !== "x64" && arch !== "arm64") {
+        throw new Error(`venmic does not provide prebuilds for architecture: ${arch}`);
+    }
 }

--- a/hak/@vencord/venmic/hak.json
+++ b/hak/@vencord/venmic/hak.json
@@ -1,0 +1,7 @@
+{
+    "scripts": {
+        "check": "check.ts",
+        "build": "build.ts"
+    },
+    "copy": "venmic.node"
+}

--- a/knip.ts
+++ b/knip.ts
@@ -6,6 +6,8 @@ export default {
     ignoreDependencies: [
         // Brought in via hak scripts
         "matrix-seshat",
+        // Native optional dependency for Linux audio sharing
+        "@vencord/venmic",
         // Required for `action-validator`
         "@action-validator/*",
         // Used for git pre-commit hooks

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     },
     "devDependencies": {
         "@action-validator/cli": "^0.6.0",
+        "@vector-im/compound-design-tokens": "^6.10.1",
         "@action-validator/core": "^0.6.0",
         "@babel/core": "^7.18.10",
         "@babel/preset-env": "^7.18.10",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,8 @@
         "@vencord/venmic": "^6.1.0"
     },
     "hakDependencies": {
-        "matrix-seshat": "^4.0.1"
+        "matrix-seshat": "^4.0.1",
+        "@vencord/venmic": "^6.1.0"
     },
     "resolutions": {
         "atomically": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -127,8 +127,8 @@
     },
     "pnpm": {
         "onlyBuiltDependencies": [
-            "electron",
-            "@vencord/venmic"
+            "@vencord/venmic",
+            "electron"
         ],
         "patchedDependencies": {
             "@types/auto-launch": "patches/@types__auto-launch.patch"

--- a/package.json
+++ b/package.json
@@ -112,6 +112,9 @@
         "tsx": "^4.19.2",
         "typescript": "5.9.3"
     },
+    "optionalDependencies": {
+        "@vencord/venmic": "^6.1.0"
+    },
     "hakDependencies": {
         "matrix-seshat": "^4.0.1"
     },
@@ -124,7 +127,8 @@
     },
     "pnpm": {
         "onlyBuiltDependencies": [
-            "electron"
+            "electron",
+            "@vencord/venmic"
         ],
         "patchedDependencies": {
             "@types/auto-launch": "patches/@types__auto-launch.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^8.0.0
         version: 8.56.1(eslint@8.57.1)(typescript@5.9.3)
+      '@vector-im/compound-design-tokens':
+        specifier: ^6.10.1
+        version: 6.10.2
       app-builder-lib:
         specifier: 26.8.2
         version: 26.8.2(dmg-builder@26.8.2)(electron-builder-squirrel-windows@26.8.2)
@@ -1672,6 +1675,17 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@vector-im/compound-design-tokens@6.10.2':
+    resolution: {integrity: sha512-imid8SUZBlWwDMjtzYq+LmxAqW6n5WNotBD/AbUoAube4Vk2BNicd8b+LI+YHDdMukG6GXYUDtluQF8j5/9apw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^17 || ^18 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react:
+        optional: true
 
   '@vencord/venmic@6.1.0':
     resolution: {integrity: sha512-YiCtzml/W8tYbGhu3jm5jfbbEnl2slKKARNK0jO+8qV979k9eFnfIRTxvhMN/SWq1h8ZNJdXVwvXpffQwq0RuA==}
@@ -6383,6 +6397,8 @@ snapshots:
       eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@vector-im/compound-design-tokens@6.10.2': {}
 
   '@vencord/venmic@6.1.0':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,10 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+    optionalDependencies:
+      '@vencord/venmic':
+        specifier: ^6.1.0
+        version: 6.1.0
 
 packages:
 
@@ -1669,6 +1673,11 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
+  '@vencord/venmic@6.1.0':
+    resolution: {integrity: sha512-YiCtzml/W8tYbGhu3jm5jfbbEnl2slKKARNK0jO+8qV979k9eFnfIRTxvhMN/SWq1h8ZNJdXVwvXpffQwq0RuA==}
+    engines: {node: '>=14.15'}
+    os: [linux]
+
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
@@ -1757,6 +1766,14 @@ packages:
   applescript@1.0.0:
     resolution: {integrity: sha512-yvtNHdWvtbYEiIazXAdp/NY+BBb65/DAseqlNiJQjOx9DynuzOYDbVLBJvuc0ve0VL9x6B3OHF6eH52y9hCBtQ==}
 
+  aproba@2.1.0:
+    resolution: {integrity: sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==}
+
+  are-we-there-yet@3.0.1:
+    resolution: {integrity: sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    deprecated: This package is no longer supported.
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -1839,6 +1856,9 @@ packages:
   axe-core@4.11.1:
     resolution: {integrity: sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==}
     engines: {node: '>=4'}
+
+  axios@1.13.6:
+    resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -1966,6 +1986,10 @@ packages:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
 
+  chownr@2.0.0:
+    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
+    engines: {node: '>=10'}
+
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
@@ -2019,12 +2043,21 @@ packages:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
 
+  cmake-js@7.4.0:
+    resolution: {integrity: sha512-Lw0JxEHrmk+qNj1n9W9d4IvkDdYTBn7l2BW6XmtLj7WPpIo2shvxUy+YokfjMxAAOELNonQwX3stkPhM5xSC2Q==}
+    engines: {node: '>= 14.15.0'}
+    hasBin: true
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  color-support@1.1.3:
+    resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
+    hasBin: true
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
@@ -2059,6 +2092,9 @@ packages:
   conf@15.1.0:
     resolution: {integrity: sha512-Uy5YN9KEu0WWDaZAVJ5FAmZoaJt9rdK6kH+utItPyGsCqCgaTKkrmZx3zoE0/3q6S3bcp3Ihkk+ZqPxWxFK5og==}
     engines: {node: '>=20'}
+
+  console-control-strings@1.1.0:
+    resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -2128,6 +2164,10 @@ packages:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
 
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -2149,6 +2189,9 @@ packages:
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+
+  delegates@1.0.0:
+    resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -2598,6 +2641,15 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
+  follow-redirects@1.15.11:
+    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
@@ -2641,6 +2693,10 @@ packages:
     resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
     engines: {node: '>=10'}
 
+  fs-minipass@2.1.0:
+    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
+    engines: {node: '>= 8'}
+
   fs-minipass@3.0.3:
     resolution: {integrity: sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -2667,6 +2723,11 @@ packages:
 
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  gauge@4.0.4:
+    resolution: {integrity: sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    deprecated: This package is no longer supported.
 
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
@@ -2789,6 +2850,9 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
+  has-unicode@2.0.1:
+    resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
+
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
@@ -2885,6 +2949,9 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   ini@6.0.0:
     resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
@@ -3244,6 +3311,9 @@ packages:
     resolution: {integrity: sha512-oY4YZCU8OqDZzmCiJpo8XrATa7XNOB5oFyIpE7O0jjaIEeu6LnQrHmm/fpsYkPUENVzGJm1YdoOtvcBrQx+h2g==}
     hasBin: true
 
+  memory-stream@1.0.0:
+    resolution: {integrity: sha512-Wm13VcsPIMdG96dzILfij09PvuS3APtcKNh7M28FsCA/w6+1mjR7hhPmfFNoilX9xU7wTdhsH5lJAm6XNzdtww==}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -3342,9 +3412,17 @@ packages:
     resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
     engines: {node: '>=8'}
 
+  minipass@5.0.0:
+    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
+    engines: {node: '>=8'}
+
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  minizlib@2.1.2:
+    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
+    engines: {node: '>= 8'}
 
   minizlib@3.1.0:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
@@ -3352,6 +3430,11 @@ packages:
 
   mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
+    hasBin: true
+
+  mkdirp@1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
     hasBin: true
 
   mkdirp@3.0.1:
@@ -3382,6 +3465,13 @@ packages:
 
   node-addon-api@1.7.2:
     resolution: {integrity: sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==}
+
+  node-addon-api@8.6.0:
+    resolution: {integrity: sha512-gBVjCaqDlRUk0EwoPNKzIr9KkS9041G/q31IBShPs1Xz6UTA+EXdZADbzqAJQrpDRq71CIMnOP5VMut3SL0z5Q==}
+    engines: {node: ^18 || ^20 || >= 21}
+
+  node-api-headers@1.8.0:
+    resolution: {integrity: sha512-jfnmiKWjRAGbdD1yQS28bknFM1tbHC1oucyuMPjmkEs+kpiu76aRs40WlTmBmyEgzDM76ge1DQ7XJ3R5deiVjQ==}
 
   node-api-version@0.2.1:
     resolution: {integrity: sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==}
@@ -3447,6 +3537,11 @@ packages:
   npm-registry-fetch@19.1.1:
     resolution: {integrity: sha512-TakBap6OM1w0H73VZVDf44iFXsOS3h+L4wVMXmbWOQroZgFhMch0juN6XSzBNlD965yIKvWg2dfu7NSiaYLxtw==}
     engines: {node: ^20.17.0 || >=22.9.0}
+
+  npmlog@6.0.2:
+    resolution: {integrity: sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    deprecated: This package is no longer supported.
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -3605,6 +3700,11 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  pkg-prebuilds@0.2.1:
+    resolution: {integrity: sha512-FdOlDiRqRL7i9aYzQflhGWCoiJf/8u6Qgzq48gKsRDYejtfjvGb1U5QGSzllcqpNg2a8Swx/9fMgtuVefwU+zw==}
+    engines: {node: '>= 14.15.0'}
+    hasBin: true
+
   playwright-core@1.58.2:
     resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
     engines: {node: '>=18'}
@@ -3694,6 +3794,9 @@ packages:
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
 
@@ -3707,6 +3810,10 @@ packages:
   quick-lru@5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -3905,6 +4012,9 @@ packages:
     resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
     engines: {node: '>=10'}
 
+  set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
@@ -4093,6 +4203,10 @@ packages:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
 
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -4126,6 +4240,11 @@ packages:
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
+
+  tar@6.2.1:
+    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
+    engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tar@7.5.10:
     resolution: {integrity: sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw==}
@@ -4304,6 +4423,9 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  url-join@4.0.1:
+    resolution: {integrity: sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==}
+
   utf8-byte-length@1.0.5:
     resolution: {integrity: sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==}
 
@@ -4368,6 +4490,9 @@ packages:
     resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
     engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
+
+  wide-align@1.1.5:
+    resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
 
   winreg@1.2.4:
     resolution: {integrity: sha512-IHpzORub7kYlb8A43Iig3reOvlcBJGX9gZ0WycHhghHtA65X0LYnMRuJs+aH1abVnMJztQkvQNlltnbPi5aGIA==}
@@ -6259,6 +6384,15 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
+  '@vencord/venmic@6.1.0':
+    dependencies:
+      cmake-js: 7.4.0
+      node-addon-api: 8.6.0
+      pkg-prebuilds: 0.2.1
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   '@xmldom/xmldom@0.8.11': {}
 
   abbrev@3.0.1: {}
@@ -6365,6 +6499,15 @@ snapshots:
       - supports-color
 
   applescript@1.0.0: {}
+
+  aproba@2.1.0:
+    optional: true
+
+  are-we-there-yet@3.0.1:
+    dependencies:
+      delegates: 1.0.0
+      readable-stream: 3.6.2
+    optional: true
 
   argparse@2.0.1: {}
 
@@ -6473,6 +6616,15 @@ snapshots:
       possible-typed-array-names: 1.1.0
 
   axe-core@4.11.1: {}
+
+  axios@1.13.6(debug@4.4.3):
+    dependencies:
+      follow-redirects: 1.15.11(debug@4.4.3)
+      form-data: 4.0.5
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+    optional: true
 
   axobject-query@4.1.0: {}
 
@@ -6654,6 +6806,9 @@ snapshots:
     dependencies:
       readdirp: 5.0.0
 
+  chownr@2.0.0:
+    optional: true
+
   chownr@3.0.0: {}
 
   chromium-pickle-js@0.2.0: {}
@@ -6701,11 +6856,32 @@ snapshots:
 
   clone@1.0.4: {}
 
+  cmake-js@7.4.0:
+    dependencies:
+      axios: 1.13.6(debug@4.4.3)
+      debug: 4.4.3
+      fs-extra: 11.3.3
+      memory-stream: 1.0.0
+      node-api-headers: 1.8.0
+      npmlog: 6.0.2
+      rc: 1.2.8
+      semver: 7.7.4
+      tar: 6.2.1
+      url-join: 4.0.1
+      which: 2.0.2
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  color-support@1.1.3:
+    optional: true
 
   colorette@2.0.20: {}
 
@@ -6737,6 +6913,9 @@ snapshots:
       json-schema-typed: 8.0.2
       semver: 7.7.4
       uint8array-extras: 1.5.0
+
+  console-control-strings@1.1.0:
+    optional: true
 
   convert-source-map@2.0.0: {}
 
@@ -6809,6 +6988,9 @@ snapshots:
     dependencies:
       mimic-response: 3.1.0
 
+  deep-extend@0.6.0:
+    optional: true
+
   deep-is@0.1.4: {}
 
   defaults@1.0.4:
@@ -6830,6 +7012,9 @@ snapshots:
       object-keys: 1.1.1
 
   delayed-stream@1.0.0: {}
+
+  delegates@1.0.0:
+    optional: true
 
   detect-libc@2.1.2: {}
 
@@ -7504,6 +7689,11 @@ snapshots:
 
   flatted@3.3.3: {}
 
+  follow-redirects@1.15.11(debug@4.4.3):
+    optionalDependencies:
+      debug: 4.4.3
+    optional: true
+
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
@@ -7560,6 +7750,11 @@ snapshots:
       jsonfile: 6.2.0
       universalify: 2.0.1
 
+  fs-minipass@2.1.0:
+    dependencies:
+      minipass: 3.3.6
+    optional: true
+
   fs-minipass@3.0.3:
     dependencies:
       minipass: 7.1.3
@@ -7584,6 +7779,18 @@ snapshots:
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
+
+  gauge@4.0.4:
+    dependencies:
+      aproba: 2.1.0
+      color-support: 1.1.3
+      console-control-strings: 1.1.0
+      has-unicode: 2.0.1
+      signal-exit: 3.0.7
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wide-align: 1.1.5
+    optional: true
 
   generator-function@2.0.1: {}
 
@@ -7731,6 +7938,9 @@ snapshots:
     dependencies:
       has-symbols: 1.1.0
 
+  has-unicode@2.0.1:
+    optional: true
+
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
@@ -7825,6 +8035,9 @@ snapshots:
       wrappy: 1.0.2
 
   inherits@2.0.4: {}
+
+  ini@1.3.8:
+    optional: true
 
   ini@6.0.0: {}
 
@@ -8215,6 +8428,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  memory-stream@1.0.0:
+    dependencies:
+      readable-stream: 3.6.2
+    optional: true
+
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
@@ -8306,7 +8524,16 @@ snapshots:
     dependencies:
       yallist: 4.0.0
 
+  minipass@5.0.0:
+    optional: true
+
   minipass@7.1.3: {}
+
+  minizlib@2.1.2:
+    dependencies:
+      minipass: 3.3.6
+      yallist: 4.0.0
+    optional: true
 
   minizlib@3.1.0:
     dependencies:
@@ -8315,6 +8542,9 @@ snapshots:
   mkdirp@0.5.6:
     dependencies:
       minimist: 1.2.8
+
+  mkdirp@1.0.4:
+    optional: true
 
   mkdirp@3.0.1: {}
 
@@ -8333,6 +8563,12 @@ snapshots:
       semver: 7.7.4
 
   node-addon-api@1.7.2:
+    optional: true
+
+  node-addon-api@8.6.0:
+    optional: true
+
+  node-api-headers@1.8.0:
     optional: true
 
   node-api-version@0.2.1:
@@ -8436,6 +8672,14 @@ snapshots:
       proc-log: 6.1.0
     transitivePeerDependencies:
       - supports-color
+
+  npmlog@6.0.2:
+    dependencies:
+      are-we-there-yet: 3.0.1
+      console-control-strings: 1.1.0
+      gauge: 4.0.4
+      set-blocking: 2.0.0
+    optional: true
 
   object-assign@4.1.1: {}
 
@@ -8640,6 +8884,11 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  pkg-prebuilds@0.2.1:
+    dependencies:
+      yargs: 17.7.2
+    optional: true
+
   playwright-core@1.58.2: {}
 
   playwright@1.58.2:
@@ -8712,6 +8961,9 @@ snapshots:
       retry: 0.12.0
       signal-exit: 3.0.7
 
+  proxy-from-env@1.1.0:
+    optional: true
+
   pump@3.0.3:
     dependencies:
       end-of-stream: 1.4.5
@@ -8722,6 +8974,14 @@ snapshots:
   queue-microtask@1.2.3: {}
 
   quick-lru@5.1.1: {}
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
+    optional: true
 
   react-is@16.13.1: {}
 
@@ -8939,6 +9199,9 @@ snapshots:
   serialize-error@7.0.1:
     dependencies:
       type-fest: 0.13.1
+    optional: true
+
+  set-blocking@2.0.0:
     optional: true
 
   set-function-length@1.2.2:
@@ -9192,6 +9455,9 @@ snapshots:
     dependencies:
       min-indent: 1.0.1
 
+  strip-json-comments@2.0.1:
+    optional: true
+
   strip-json-comments@3.1.1: {}
 
   strip-json-comments@5.0.3: {}
@@ -9217,6 +9483,16 @@ snapshots:
   tagged-tag@1.0.0: {}
 
   tapable@2.3.0: {}
+
+  tar@6.2.1:
+    dependencies:
+      chownr: 2.0.0
+      fs-minipass: 2.1.0
+      minipass: 5.0.0
+      minizlib: 2.1.2
+      mkdirp: 1.0.4
+      yallist: 4.0.0
+    optional: true
 
   tar@7.5.10:
     dependencies:
@@ -9409,6 +9685,9 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  url-join@4.0.1:
+    optional: true
+
   utf8-byte-length@1.0.5: {}
 
   util-deprecate@1.0.2: {}
@@ -9493,6 +9772,11 @@ snapshots:
   which@6.0.1:
     dependencies:
       isexe: 4.0.0
+
+  wide-align@1.1.5:
+    dependencies:
+      string-width: 4.2.3
+    optional: true
 
   winreg@1.2.4: {}
 

--- a/scripts/copy-res.ts
+++ b/scripts/copy-res.ts
@@ -79,3 +79,20 @@ INCLUDE_LANGS.forEach((file): void => {
 if (watch) {
     INCLUDE_LANGS.forEach((file) => watchLanguage(I18N_BASE_PATH + file, I18N_DEST));
 }
+
+// Compound Design Tokens CSS — copy to build/compound/ for use by audio-picker.html
+const CPD_CSS_SRC = "node_modules/@vector-im/compound-design-tokens/assets/web/css/";
+const CPD_CSS_DEST = "build/compound/";
+if (fs.existsSync(CPD_CSS_SRC)) {
+    fs.mkdirSync(CPD_CSS_DEST, { recursive: true });
+    for (const file of fs.readdirSync(CPD_CSS_SRC)) {
+        if (file.endsWith(".css")) {
+            fs.copyFileSync(path.join(CPD_CSS_SRC, file), path.join(CPD_CSS_DEST, file));
+            if (verbose) {
+                console.log("Copied Compound CSS: " + file);
+            }
+        }
+    }
+} else {
+    console.warn("Compound Design Tokens CSS not found at " + CPD_CSS_SRC + ", skipping copy");
+}

--- a/scripts/copy-res.ts
+++ b/scripts/copy-res.ts
@@ -79,3 +79,26 @@ INCLUDE_LANGS.forEach((file): void => {
 if (watch) {
     INCLUDE_LANGS.forEach((file) => watchLanguage(I18N_BASE_PATH + file, I18N_DEST));
 }
+
+// Copy venmic native addon for Linux audio sharing
+// Only copy on Linux since venmic is Linux-only
+if (process.platform === "linux") {
+    const venmicSource = path.join(
+        "node_modules",
+        "@vencord",
+        "venmic",
+        "prebuilds",
+        `venmic-addon-linux-${process.arch}`,
+        "node-napi-v7.node",
+    );
+
+    if (fs.existsSync(venmicSource)) {
+        const venmicDest = path.join("lib", `venmic-${process.arch}.node`);
+        fs.copyFileSync(venmicSource, venmicDest);
+        if (verbose) {
+            console.log(`Copied venmic native addon to ${venmicDest}`);
+        }
+    } else if (verbose) {
+        console.log("venmic native addon not found, skipping (optional dependency)");
+    }
+}

--- a/scripts/copy-res.ts
+++ b/scripts/copy-res.ts
@@ -79,26 +79,3 @@ INCLUDE_LANGS.forEach((file): void => {
 if (watch) {
     INCLUDE_LANGS.forEach((file) => watchLanguage(I18N_BASE_PATH + file, I18N_DEST));
 }
-
-// Copy venmic native addon for Linux audio sharing
-// Only copy on Linux since venmic is Linux-only
-if (process.platform === "linux") {
-    const venmicSource = path.join(
-        "node_modules",
-        "@vencord",
-        "venmic",
-        "prebuilds",
-        `venmic-addon-linux-${process.arch}`,
-        "node-napi-v7.node",
-    );
-
-    if (fs.existsSync(venmicSource)) {
-        const venmicDest = path.join("lib", `venmic-${process.arch}.node`);
-        fs.copyFileSync(venmicSource, venmicDest);
-        if (verbose) {
-            console.log(`Copied venmic native addon to ${venmicDest}`);
-        }
-    } else if (verbose) {
-        console.log("venmic native addon not found, skipping (optional dependency)");
-    }
-}

--- a/src/@types/audio-sharing.d.ts
+++ b/src/@types/audio-sharing.d.ts
@@ -9,7 +9,9 @@ import type { Node } from "@vencord/venmic";
 
 /** User's audio source selection from the audio picker. */
 export interface AudioSelection {
+    /** The type of audio source: "none" (no audio), "system" (all system audio), or "app" (specific application). */
     type: "none" | "system" | "app";
+    /** The PipeWire node to capture audio from. Only set when type is "app". */
     node?: Node;
 }
 

--- a/src/@types/audio-sharing.d.ts
+++ b/src/@types/audio-sharing.d.ts
@@ -1,0 +1,19 @@
+/*
+Copyright 2025 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import type { Node } from "@vencord/venmic";
+
+/** User's audio source selection from the audio picker. */
+export interface AudioSelection {
+    type: "none" | "system" | "app";
+    node?: Node;
+}
+
+/** Result of listing available venmic audio nodes. */
+export type VenmicListResult =
+    | { ok: true; targets: Node[]; hasPipewirePulse: boolean }
+    | { ok: false; isGlibcOutdated: boolean };

--- a/src/@types/audio-sharing.d.ts
+++ b/src/@types/audio-sharing.d.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 New Vector Ltd.
+Copyright 2026 Joao Costa <me@joaocosta.dev>
 
 SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
 Please see LICENSE files in the repository root for full details.

--- a/src/@types/vencord__venmic.d.ts
+++ b/src/@types/vencord__venmic.d.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 New Vector Ltd.
+Copyright 2026 Joao Costa <me@joaocosta.dev>
 
 SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
 Please see LICENSE files in the repository root for full details.

--- a/src/@types/vencord__venmic.d.ts
+++ b/src/@types/vencord__venmic.d.ts
@@ -1,0 +1,36 @@
+/*
+Copyright 2025 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+declare module "@vencord/venmic" {
+    /** A PipeWire node represented as key-value pairs of its properties. */
+    export type Node = Record<string, string>;
+
+    /** Configuration for linking audio sources to the virtual microphone. */
+    export interface LinkData {
+        include: Node[];
+        exclude: Node[];
+        ignore_devices?: boolean;
+        only_speakers?: boolean;
+        only_default_speakers?: boolean;
+        workaround?: Node[];
+    }
+
+    /** PipeWire audio patchbay for creating virtual microphone sources. */
+    export class PatchBay {
+        /** Check whether PipeWire is available on the system. */
+        public static hasPipeWire(): boolean;
+
+        /** List available audio nodes. Optionally filter by specific properties. */
+        public list(props?: string[]): Node[];
+
+        /** Link audio sources to the virtual microphone. */
+        public link(data: LinkData): boolean;
+
+        /** Unlink (destroy) the virtual microphone. */
+        public unlink(): void;
+    }
+}

--- a/src/audio-picker-preload.cts
+++ b/src/audio-picker-preload.cts
@@ -10,18 +10,7 @@ Please see LICENSE files in the repository root for full details.
 
 import { contextBridge, ipcRenderer } from "electron";
 
-import type { Node } from "@vencord/venmic";
-
-export interface AudioSelection {
-    type: "none" | "system" | "app";
-    node?: Node;
-}
-
-export interface VenmicListResult {
-    ok: true;
-    targets: Node[];
-    hasPipewirePulse: boolean;
-}
+import type { AudioSelection, VenmicListResult } from "./@types/audio-sharing.js" with { "resolution-mode": "import" };
 
 contextBridge.exposeInMainWorld("audioPickerAPI", {
     /**

--- a/src/audio-picker-preload.cts
+++ b/src/audio-picker-preload.cts
@@ -14,6 +14,13 @@ import type { AudioSelection, VenmicListResult } from "./@types/audio-sharing.js
 
 contextBridge.exposeInMainWorld("audioPickerAPI", {
     /**
+     * Get configuration for the audio picker (theme, etc).
+     */
+    getConfig(): Promise<{ theme: string }> {
+        return ipcRenderer.invoke("audio-picker-get-config");
+    },
+
+    /**
      * Get available audio sources from venmic.
      */
     getSources(): Promise<VenmicListResult> {

--- a/src/audio-picker-preload.cts
+++ b/src/audio-picker-preload.cts
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 New Vector Ltd.
+Copyright 2026 Joao Costa <me@joaocosta.dev>
 
 SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
 Please see LICENSE files in the repository root for full details.

--- a/src/audio-picker-preload.cts
+++ b/src/audio-picker-preload.cts
@@ -1,0 +1,47 @@
+/*
+Copyright 2025 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+// Preload script for the audio picker dialog window.
+// This file is compiled to CommonJS for Electron compatibility.
+
+import { contextBridge, ipcRenderer } from "electron";
+
+import type { Node } from "@vencord/venmic";
+
+export interface AudioSelection {
+    type: "none" | "system" | "app";
+    node?: Node;
+}
+
+export interface VenmicListResult {
+    ok: true;
+    targets: Node[];
+    hasPipewirePulse: boolean;
+}
+
+contextBridge.exposeInMainWorld("audioPickerAPI", {
+    /**
+     * Get available audio sources from venmic.
+     */
+    getSources(): Promise<VenmicListResult> {
+        return ipcRenderer.invoke("audio-picker-get-sources");
+    },
+
+    /**
+     * Send the user's selection back to the main process.
+     */
+    submitSelection(selection: AudioSelection): void {
+        ipcRenderer.send("audio-picker-result", selection);
+    },
+
+    /**
+     * Cancel the picker (same as selecting "none").
+     */
+    cancel(): void {
+        ipcRenderer.send("audio-picker-result", { type: "none" });
+    },
+});

--- a/src/audio-picker-preload.cts
+++ b/src/audio-picker-preload.cts
@@ -21,6 +21,13 @@ contextBridge.exposeInMainWorld("audioPickerAPI", {
     },
 
     /**
+     * Get translated UI strings for the audio picker.
+     */
+    getStrings(): Promise<Record<string, string>> {
+        return ipcRenderer.invoke("audio-picker-get-strings");
+    },
+
+    /**
      * Send the user's selection back to the main process.
      */
     submitSelection(selection: AudioSelection): void {

--- a/src/audio-picker.ts
+++ b/src/audio-picker.ts
@@ -5,15 +5,16 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
-import { app, BrowserWindow, ipcMain } from "electron";
+import { app, BrowserWindow, ipcMain, nativeTheme } from "electron";
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import type { AudioSelection, VenmicListResult } from "./@types/audio-sharing.js";
-export type { AudioSelection } from "./@types/audio-sharing.js";
 import { _t } from "./language-helper.js";
 import { listVenmicNodes, startVenmicDirect, startVenmicSystemDirect, stopVenmicDirect } from "./venmic.js";
+
+export type { AudioSelection } from "./@types/audio-sharing.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -55,6 +56,24 @@ export async function showAudioPicker(parentWindow: BrowserWindow): Promise<Audi
         return { type: "none" };
     }
 
+    // Detect the active Compound theme from the parent window's <body> class.
+    // element-web sets one of: cpd-theme-light, cpd-theme-dark, cpd-theme-light-hc, cpd-theme-dark-hc
+    let compoundTheme = "";
+    try {
+        const themeClass: string = await parentWindow.webContents.executeJavaScript(
+            `[...document.body.classList].find(c => c.startsWith("cpd-theme-")) || ""`,
+        );
+        // Strip the "cpd-theme-" prefix to get "light", "dark", "light-hc", or "dark-hc"
+        compoundTheme = themeClass.replace("cpd-theme-", "");
+    } catch (e) {
+        console.warn("audio-picker: failed to detect theme from parent window:", e);
+    }
+
+    // Fallback to system preference if detection failed or returned empty
+    if (!compoundTheme) {
+        compoundTheme = nativeTheme.shouldUseDarkColors ? "dark" : "light";
+    }
+
     return new Promise((resolve) => {
         const pickerWindow = new BrowserWindow({
             parent: parentWindow,
@@ -91,6 +110,8 @@ export async function showAudioPicker(parentWindow: BrowserWindow): Promise<Audi
             return audioSources;
         };
 
+        const handleGetConfig = (): { theme: string } => ({ theme: compoundTheme });
+
         const handleGetStrings = (): Record<string, string> => ({
             title: _t("audio_picker|title"),
             subtitle: _t("audio_picker|subtitle"),
@@ -110,12 +131,14 @@ export async function showAudioPicker(parentWindow: BrowserWindow): Promise<Audi
 
         const cleanup = (): void => {
             ipcMain.removeListener("audio-picker-result", handleResult);
+            ipcMain.removeHandler("audio-picker-get-config");
             ipcMain.removeHandler("audio-picker-get-sources");
             ipcMain.removeHandler("audio-picker-get-strings");
         };
 
         // Register handlers BEFORE loading the page
         ipcMain.on("audio-picker-result", handleResult);
+        ipcMain.handle("audio-picker-get-config", handleGetConfig);
         ipcMain.handle("audio-picker-get-sources", handleGetSources);
         ipcMain.handle("audio-picker-get-strings", handleGetStrings);
 

--- a/src/audio-picker.ts
+++ b/src/audio-picker.ts
@@ -10,14 +10,10 @@ import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import type { Node } from "@vencord/venmic";
-import {
-    type VenmicListResult,
-    listVenmicNodes,
-    startVenmicDirect,
-    startVenmicSystemDirect,
-    stopVenmicDirect,
-} from "./venmic.js";
+import type { AudioSelection, VenmicListResult } from "./@types/audio-sharing.js";
+import { listVenmicNodes, startVenmicDirect, startVenmicSystemDirect, stopVenmicDirect } from "./venmic.js";
+
+export type { AudioSelection };
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -44,11 +40,6 @@ function getAudioPickerHtmlPath(): string {
     // Fallback to first candidate (will error if not found)
     console.warn("audio-picker: could not find audio-picker.html, tried:", candidates);
     return candidates[0];
-}
-
-export interface AudioSelection {
-    type: "none" | "system" | "app";
-    node?: Node;
 }
 
 /**

--- a/src/audio-picker.ts
+++ b/src/audio-picker.ts
@@ -11,9 +11,9 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import type { AudioSelection, VenmicListResult } from "./@types/audio-sharing.js";
+export type { AudioSelection } from "./@types/audio-sharing.js";
+import { _t } from "./language-helper.js";
 import { listVenmicNodes, startVenmicDirect, startVenmicSystemDirect, stopVenmicDirect } from "./venmic.js";
-
-export type { AudioSelection };
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -65,7 +65,7 @@ export async function showAudioPicker(parentWindow: BrowserWindow): Promise<Audi
             minimizable: false,
             maximizable: false,
             fullscreenable: false,
-            title: "Share Audio",
+            title: _t("audio_picker|title"),
             webPreferences: {
                 preload: join(__dirname, "audio-picker-preload.cjs"),
                 contextIsolation: true,
@@ -91,14 +91,33 @@ export async function showAudioPicker(parentWindow: BrowserWindow): Promise<Audi
             return audioSources;
         };
 
+        const handleGetStrings = (): Record<string, string> => ({
+            title: _t("audio_picker|title"),
+            subtitle: _t("audio_picker|subtitle"),
+            loading: _t("audio_picker|loading"),
+            share: _t("audio_picker|share"),
+            cancel: _t("action|cancel"),
+            noAudioLabel: _t("audio_picker|no_audio_label"),
+            noAudioDescription: _t("audio_picker|no_audio_description"),
+            systemLabel: _t("audio_picker|system_label"),
+            systemDescription: _t("audio_picker|system_description"),
+            applicationsHeader: _t("audio_picker|applications_header"),
+            noApps: _t("audio_picker|no_apps"),
+            errorLoadPrefix: _t("audio_picker|error_load_prefix"),
+            errorGlibc: _t("audio_picker|error_glibc"),
+            errorPipewire: _t("audio_picker|error_pipewire"),
+        });
+
         const cleanup = (): void => {
             ipcMain.removeListener("audio-picker-result", handleResult);
             ipcMain.removeHandler("audio-picker-get-sources");
+            ipcMain.removeHandler("audio-picker-get-strings");
         };
 
         // Register handlers BEFORE loading the page
         ipcMain.on("audio-picker-result", handleResult);
         ipcMain.handle("audio-picker-get-sources", handleGetSources);
+        ipcMain.handle("audio-picker-get-strings", handleGetStrings);
 
         pickerWindow.on("closed", () => {
             if (!resolved) {

--- a/src/audio-picker.ts
+++ b/src/audio-picker.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 New Vector Ltd.
+Copyright 2026 Joao Costa <me@joaocosta.dev>
 
 SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
 Please see LICENSE files in the repository root for full details.

--- a/src/audio-picker.ts
+++ b/src/audio-picker.ts
@@ -1,0 +1,148 @@
+/*
+Copyright 2025 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import { app, BrowserWindow, ipcMain } from "electron";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type { Node } from "@vencord/venmic";
+import {
+    type VenmicListResult,
+    listVenmicNodes,
+    startVenmicDirect,
+    startVenmicSystemDirect,
+    stopVenmicDirect,
+} from "./venmic.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Find the audio picker HTML file path.
+ * Tries multiple locations to work in both development and packaged app.
+ */
+function getAudioPickerHtmlPath(): string {
+    const candidates = [
+        // Development: src -> build/audio-picker.html
+        join(__dirname, "..", "build", "audio-picker.html"),
+        // Packaged app: resources/build/audio-picker.html
+        join(app.getAppPath(), "..", "build", "audio-picker.html"),
+        // Packaged app alternative: app.asar.unpacked or similar
+        join(app.getAppPath(), "build", "audio-picker.html"),
+    ];
+
+    for (const candidate of candidates) {
+        if (existsSync(candidate)) {
+            return candidate;
+        }
+    }
+
+    // Fallback to first candidate (will error if not found)
+    console.warn("audio-picker: could not find audio-picker.html, tried:", candidates);
+    return candidates[0];
+}
+
+export interface AudioSelection {
+    type: "none" | "system" | "app";
+    node?: Node;
+}
+
+/**
+ * Shows a native dialog for selecting audio sources to share.
+ * Returns the user's selection or "none" if cancelled.
+ */
+export async function showAudioPicker(parentWindow: BrowserWindow): Promise<AudioSelection> {
+    const audioSources = listVenmicNodes();
+
+    // If venmic isn't available or no PipeWire, skip the picker
+    if (!audioSources.ok || !audioSources.hasPipewirePulse) {
+        console.log("venmic not available or no PipeWire, skipping audio picker");
+        return { type: "none" };
+    }
+
+    return new Promise((resolve) => {
+        const pickerWindow = new BrowserWindow({
+            parent: parentWindow,
+            modal: true,
+            width: 420,
+            height: 520,
+            resizable: false,
+            minimizable: false,
+            maximizable: false,
+            fullscreenable: false,
+            title: "Share Audio",
+            webPreferences: {
+                preload: join(__dirname, "audio-picker-preload.cjs"),
+                contextIsolation: true,
+                nodeIntegration: false,
+                sandbox: false, // Required for IPC to work properly
+            },
+        });
+
+        pickerWindow.setMenu(null);
+
+        let resolved = false;
+
+        const handleResult = (_event: Electron.IpcMainEvent, selection: AudioSelection): void => {
+            if (resolved) return;
+            resolved = true;
+            cleanup();
+            pickerWindow.close();
+            resolve(selection);
+        };
+
+        const handleGetSources = (): VenmicListResult => {
+            console.log("audio-picker: getSources called, returning", audioSources.targets?.length, "sources");
+            return audioSources;
+        };
+
+        const cleanup = (): void => {
+            ipcMain.removeListener("audio-picker-result", handleResult);
+            ipcMain.removeHandler("audio-picker-get-sources");
+        };
+
+        // Register handlers BEFORE loading the page
+        ipcMain.on("audio-picker-result", handleResult);
+        ipcMain.handle("audio-picker-get-sources", handleGetSources);
+
+        pickerWindow.on("closed", () => {
+            if (!resolved) {
+                resolved = true;
+                cleanup();
+                resolve({ type: "none" });
+            }
+        });
+
+        // Add error handling for debugging
+        pickerWindow.webContents.on("console-message", (_event, _level, message) => {
+            console.log("audio-picker renderer:", message);
+        });
+
+        pickerWindow.loadFile(getAudioPickerHtmlPath());
+    });
+}
+
+/**
+ * Shows audio picker and starts venmic based on user selection.
+ * Returns true if audio was started, false otherwise.
+ */
+export async function showAudioPickerAndStart(parentWindow: BrowserWindow): Promise<boolean> {
+    const selection = await showAudioPicker(parentWindow);
+
+    switch (selection.type) {
+        case "system":
+            return startVenmicSystemDirect([]) ?? false;
+        case "app":
+            if (selection.node) {
+                return startVenmicDirect([selection.node]) ?? false;
+            }
+            return false;
+        default:
+            stopVenmicDirect();
+            return false;
+    }
+}

--- a/src/displayMediaCallback.ts
+++ b/src/displayMediaCallback.ts
@@ -10,6 +10,7 @@ import type { Streams } from "electron";
 type DisplayMediaCallback = (streams: Streams) => void;
 
 let displayMediaCallback: DisplayMediaCallback | null;
+let audioRequested = false;
 
 export const getDisplayMediaCallback = (): DisplayMediaCallback | null => {
     return displayMediaCallback;
@@ -17,4 +18,12 @@ export const getDisplayMediaCallback = (): DisplayMediaCallback | null => {
 
 export const setDisplayMediaCallback = (callback: DisplayMediaCallback | null): void => {
     displayMediaCallback = callback;
+};
+
+export const getAudioRequested = (): boolean => {
+    return audioRequested;
+};
+
+export const setAudioRequested = (requested: boolean): void => {
+    audioRequested = requested;
 };

--- a/src/displayMediaCallback.ts
+++ b/src/displayMediaCallback.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023, 2024 New Vector Ltd.
+Copyright 2026 Joao Costa <me@joaocosta.dev>
 
 SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
 Please see LICENSE files in the repository root for full details.

--- a/src/displayMediaCallback.ts
+++ b/src/displayMediaCallback.ts
@@ -20,10 +20,18 @@ export const setDisplayMediaCallback = (callback: DisplayMediaCallback | null): 
     displayMediaCallback = callback;
 };
 
+/**
+ * Get whether audio was requested for the current display media callback.
+ * Used to determine if the audio picker should be shown on Linux.
+ */
 export const getAudioRequested = (): boolean => {
     return audioRequested;
 };
 
+/**
+ * Set whether audio was requested for the current display media callback.
+ * @param requested - Whether audio sharing was requested
+ */
 export const setAudioRequested = (requested: boolean): void => {
     audioRequested = requested;
 };

--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -584,9 +584,7 @@ app.on("ready", async () => {
     webContentsHandler(global.mainWindow.webContents);
 
     // Set up venmic injection for Linux audio sharing in iframes (Element Call)
-    if (setupVenmicInjection) {
-        setupVenmicInjection(global.mainWindow.webContents);
-    }
+    setupVenmicInjection?.(global.mainWindow.webContents);
 
     session.defaultSession.setDisplayMediaRequestHandler(
         async (request, callback) => {

--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -47,6 +47,10 @@ import { type Json, loadJsonFile } from "./utils.js";
 import { setupMediaAuth } from "./media-auth.js";
 import { readBuildConfig } from "./build-config.js";
 
+if (process.platform === "linux") {
+    await import("./venmic.js");
+}
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const argv = minimist(process.argv, {

--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -46,9 +46,16 @@ import { setupMacosTitleBar } from "./macos-titlebar.js";
 import { type Json, loadJsonFile } from "./utils.js";
 import { setupMediaAuth } from "./media-auth.js";
 import { readBuildConfig } from "./build-config.js";
+import type { showAudioPickerAndStart as ShowAudioPickerAndStartType } from "./audio-picker.js";
+import type { setupVenmicInjection as SetupVenmicInjectionType } from "./venmic-inject.js";
+
+let showAudioPickerAndStart: typeof ShowAudioPickerAndStartType | undefined;
+let setupVenmicInjection: typeof SetupVenmicInjectionType | undefined;
 
 if (process.platform === "linux") {
     await import("./venmic.js");
+    showAudioPickerAndStart = (await import("./audio-picker.js")).showAudioPickerAndStart;
+    setupVenmicInjection = (await import("./venmic-inject.js")).setupVenmicInjection;
 }
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -576,26 +583,41 @@ app.on("ready", async () => {
 
     webContentsHandler(global.mainWindow.webContents);
 
+    // Set up venmic injection for Linux audio sharing in iframes (Element Call)
+    if (setupVenmicInjection) {
+        setupVenmicInjection(global.mainWindow.webContents);
+    }
+
     session.defaultSession.setDisplayMediaRequestHandler(
-        (request, callback) => {
+        async (request, callback) => {
             if (process.env.XDG_SESSION_TYPE === "wayland") {
                 // On Wayland, calling getSources() opens the xdg-desktop-portal picker.
                 // The user can only select a single source there, so Electron will return an array with exactly one entry.
-                desktopCapturer
-                    .getSources({ types: ["screen", "window"] })
-                    .then((sources) => {
-                        callback({ video: sources[0] });
-                    })
-                    .catch((err) => {
-                        // If the user cancels the dialog an error occurs "Failed to get sources"
-                        console.error("Wayland: failed to get user-selected source:", err);
-                        callback({ video: { id: "", name: "" } }); // The promise does not return if no dummy is passed here as source
-                    });
+                try {
+                    const sources = await desktopCapturer.getSources({ types: ["screen", "window"] });
+                    const source = sources[0];
+
+                    if (!source) {
+                        callback({ video: { id: "", name: "" } });
+                        return;
+                    }
+
+                    // Show audio picker if audio was requested and we're on Linux with venmic available
+                    if (request.audioRequested && showAudioPickerAndStart && global.mainWindow) {
+                        await showAudioPickerAndStart(global.mainWindow);
+                    }
+
+                    callback({ video: source });
+                } catch (err) {
+                    // If the user cancels the dialog an error occurs "Failed to get sources"
+                    console.error("Wayland: failed to get user-selected source:", err);
+                    callback({ video: { id: "", name: "" } }); // The promise does not return if no dummy is passed here as source
+                }
             } else {
                 global.mainWindow?.webContents.send("openDesktopCapturerSourcePicker");
+                setDisplayMediaCallback(callback);
+                setAudioRequested(request.audioRequested);
             }
-            setDisplayMediaCallback(callback);
-            setAudioRequested(request.audioRequested);
         },
         { useSystemPicker: true },
     ); // Use Mac OS 15+ native picker

--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -41,7 +41,7 @@ import webContentsHandler from "./webcontents-handler.js";
 import * as updater from "./updater.js";
 import ProtocolHandler from "./protocol.js";
 import { _t, AppLocalization } from "./language-helper.js";
-import { setDisplayMediaCallback } from "./displayMediaCallback.js";
+import { setDisplayMediaCallback, setAudioRequested } from "./displayMediaCallback.js";
 import { setupMacosTitleBar } from "./macos-titlebar.js";
 import { type Json, loadJsonFile } from "./utils.js";
 import { setupMediaAuth } from "./media-auth.js";
@@ -573,7 +573,7 @@ app.on("ready", async () => {
     webContentsHandler(global.mainWindow.webContents);
 
     session.defaultSession.setDisplayMediaRequestHandler(
-        (_, callback) => {
+        (request, callback) => {
             if (process.env.XDG_SESSION_TYPE === "wayland") {
                 // On Wayland, calling getSources() opens the xdg-desktop-portal picker.
                 // The user can only select a single source there, so Electron will return an array with exactly one entry.
@@ -591,6 +591,7 @@ app.on("ready", async () => {
                 global.mainWindow?.webContents.send("openDesktopCapturerSourcePicker");
             }
             setDisplayMediaCallback(callback);
+            setAudioRequested(request.audioRequested);
         },
         { useSystemPicker: true },
     ); // Use Mac OS 15+ native picker

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -84,6 +84,22 @@
         "toggle_full_screen": "Toggle Full Screen",
         "view": "View"
     },
+    "audio_picker": {
+        "title": "Share Audio",
+        "subtitle": "Choose what audio to share with the call",
+        "loading": "Loading audio sources…",
+        "share": "Share",
+        "no_audio_label": "No audio",
+        "no_audio_description": "Share screen only",
+        "system_label": "Entire system",
+        "system_description": "Share all audio from your computer",
+        "applications_header": "Applications",
+        "no_apps": "No applications are currently playing audio",
+        "error_load_prefix": "Unable to load audio sources.",
+        "error_glibc": "Your system's GLIBC version may be too old.",
+        "error_pipewire": "PipeWire may not be available.",
+        "error_load_fail": "Failed to load audio sources: %(error)s"
+    },
     "window_menu": {
         "bring_all_to_front": "Bring All to Front",
         "label": "Window",

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -148,11 +148,19 @@ ipcMain.on("ipcCall", async function (_ev: IpcMainEvent, payload) {
             }));
             break;
         case "callDisplayMediaCallback": {
-            const shouldIncludeAudio = getAudioRequested() && process.platform === "win32";
+            const audioRequested = getAudioRequested();
             const callback = getDisplayMediaCallback();
             setDisplayMediaCallback(null);
             setAudioRequested(false);
-            if (shouldIncludeAudio) {
+
+            // Show audio picker for Linux (X11 path - Wayland is handled in electron-main.ts)
+            if (audioRequested && process.platform === "linux" && global.mainWindow) {
+                const { showAudioPickerAndStart } = await import("./audio-picker.js");
+                await showAudioPickerAndStart(global.mainWindow);
+            }
+
+            // Include loopback audio for Windows
+            if (audioRequested && process.platform === "win32") {
                 await callback?.({ video: args[0], audio: "loopback" });
             } else {
                 await callback?.({ video: args[0] });

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -9,7 +9,12 @@ import { app, autoUpdater, desktopCapturer, ipcMain, powerSaveBlocker, TouchBar,
 
 import IpcMainEvent = Electron.IpcMainEvent;
 import { randomArray } from "./utils.js";
-import { getDisplayMediaCallback, setDisplayMediaCallback } from "./displayMediaCallback.js";
+import {
+    getDisplayMediaCallback,
+    setDisplayMediaCallback,
+    getAudioRequested,
+    setAudioRequested,
+} from "./displayMediaCallback.js";
 import Store, { clearDataAndRelaunch } from "./store.js";
 
 let focusHandlerAttached = false;
@@ -142,11 +147,19 @@ ipcMain.on("ipcCall", async function (_ev: IpcMainEvent, payload) {
                 thumbnailURL: source.thumbnail.toDataURL(),
             }));
             break;
-        case "callDisplayMediaCallback":
-            await getDisplayMediaCallback()?.({ video: args[0] });
+        case "callDisplayMediaCallback": {
+            const shouldIncludeAudio = getAudioRequested() && process.platform === "win32";
+            const callback = getDisplayMediaCallback();
             setDisplayMediaCallback(null);
+            setAudioRequested(false);
+            if (shouldIncludeAudio) {
+                await callback?.({ video: args[0], audio: "loopback" });
+            } else {
+                await callback?.({ video: args[0] });
+            }
             ret = null;
             break;
+        }
 
         case "clearStorage":
             await clearDataAndRelaunch(global.mainWindow.webContents.session);

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -159,12 +159,7 @@ ipcMain.on("ipcCall", async function (_ev: IpcMainEvent, payload) {
                 await showAudioPickerAndStart(global.mainWindow);
             }
 
-            // Include loopback audio for Windows
-            if (audioRequested && process.platform === "win32") {
-                await callback?.({ video: args[0], audio: "loopback" });
-            } else {
-                await callback?.({ video: args[0] });
-            }
+            callback?.({ video: args[0] });
             ret = null;
             break;
         }

--- a/src/preload.cts
+++ b/src/preload.cts
@@ -8,6 +8,8 @@ Please see LICENSE files in the repository root for full details.
 
 // This file is compiled to CommonJS rather than ESM otherwise the browser chokes on the import statement.
 
+/// <reference lib="dom" />
+
 import { ipcRenderer, contextBridge, IpcRendererEvent } from "electron";
 
 // Expose only expected IPC wrapper APIs to the renderer process to avoid
@@ -103,3 +105,91 @@ contextBridge.exposeInMainWorld("electron", {
         },
     },
 });
+
+/**
+ * Patch navigator.mediaDevices.getDisplayMedia on Linux to capture audio from
+ * the venmic virtual microphone (vencord-screen-share) when it's available.
+ *
+ * This allows screen sharing with application audio on Linux via PipeWire.
+ */
+if (process.platform === "linux") {
+    const originalGetDisplayMedia = navigator.mediaDevices.getDisplayMedia.bind(navigator.mediaDevices);
+
+    navigator.mediaDevices.getDisplayMedia = async function (
+        options?: DisplayMediaStreamOptions,
+    ): Promise<MediaStream> {
+        console.log("venmic: getDisplayMedia called with options:", options);
+
+        const stream = await originalGetDisplayMedia(options);
+        console.log(
+            "venmic: original getDisplayMedia returned stream with tracks:",
+            stream.getTracks().map((t) => `${t.kind}:${t.label}`),
+        );
+
+        // Try to find the venmic virtual microphone
+        try {
+            const devices = await navigator.mediaDevices.enumerateDevices();
+            const audioInputs = devices.filter((d) => d.kind === "audioinput");
+            console.log(
+                "venmic: available audio input devices:",
+                audioInputs.map((d) => `${d.label} (${d.deviceId.slice(0, 8)}...)`),
+            );
+
+            const venmicDevice = devices.find((d) => d.label === "vencord-screen-share");
+
+            if (venmicDevice) {
+                console.log("venmic: found vencord-screen-share device:", venmicDevice.deviceId);
+
+                // Capture audio from the venmic virtual microphone
+                const audioStream = await navigator.mediaDevices.getUserMedia({
+                    audio: {
+                        deviceId: { exact: venmicDevice.deviceId },
+                        autoGainControl: false,
+                        echoCancellation: false,
+                        noiseSuppression: false,
+                        channelCount: 2,
+                        sampleRate: 48000,
+                        sampleSize: 16,
+                    },
+                });
+
+                console.log("venmic: captured audio stream from virtual mic");
+
+                // Remove any existing audio tracks and add the venmic audio
+                stream.getAudioTracks().forEach((track) => {
+                    console.log("venmic: removing existing audio track:", track.label);
+                    stream.removeTrack(track);
+                });
+                const audioTrack = audioStream.getAudioTracks()[0];
+                stream.addTrack(audioTrack);
+
+                // Clean up venmic when the audio track ends
+                audioTrack.addEventListener("ended", () => {
+                    console.log("venmic: audio track ended, stopping venmic");
+                    void ipcRenderer.invoke("stopVenmic");
+                });
+
+                // Also clean up when the video track ends (screen share stopped)
+                const videoTrack = stream.getVideoTracks()[0];
+                if (videoTrack) {
+                    videoTrack.addEventListener("ended", () => {
+                        console.log("venmic: video track ended, stopping venmic");
+                        void ipcRenderer.invoke("stopVenmic");
+                    });
+                }
+
+                console.log("venmic: audio track added to screen share stream successfully");
+            } else {
+                console.log("venmic: vencord-screen-share device NOT found");
+            }
+        } catch (err) {
+            console.error("venmic: failed to capture audio from virtual microphone:", err);
+        }
+
+        console.log(
+            "venmic: returning stream with tracks:",
+            stream.getTracks().map((t) => `${t.kind}:${t.label}`),
+        );
+        return stream;
+    };
+}

--- a/src/preload.cts
+++ b/src/preload.cts
@@ -118,10 +118,10 @@ if (process.platform === "linux") {
     navigator.mediaDevices.getDisplayMedia = async function (
         options?: DisplayMediaStreamOptions,
     ): Promise<MediaStream> {
-        console.log("venmic: getDisplayMedia called with options:", options);
+        console.debug("venmic: getDisplayMedia called with options:", options);
 
         const stream = await originalGetDisplayMedia(options);
-        console.log(
+        console.debug(
             "venmic: original getDisplayMedia returned stream with tracks:",
             stream.getTracks().map((t) => `${t.kind}:${t.label}`),
         );
@@ -130,7 +130,7 @@ if (process.platform === "linux") {
         try {
             const devices = await navigator.mediaDevices.enumerateDevices();
             const audioInputs = devices.filter((d) => d.kind === "audioinput");
-            console.log(
+            console.debug(
                 "venmic: available audio input devices:",
                 audioInputs.map((d) => `${d.label} (${d.deviceId.slice(0, 8)}...)`),
             );
@@ -138,7 +138,7 @@ if (process.platform === "linux") {
             const venmicDevice = devices.find((d) => d.label === "vencord-screen-share");
 
             if (venmicDevice) {
-                console.log("venmic: found vencord-screen-share device:", venmicDevice.deviceId);
+                console.debug("venmic: found vencord-screen-share device:", venmicDevice.deviceId);
 
                 // Capture audio from the venmic virtual microphone
                 const audioStream = await navigator.mediaDevices.getUserMedia({
@@ -153,40 +153,44 @@ if (process.platform === "linux") {
                     },
                 });
 
-                console.log("venmic: captured audio stream from virtual mic");
+                console.debug("venmic: captured audio stream from virtual mic");
 
                 // Remove any existing audio tracks and add the venmic audio
-                stream.getAudioTracks().forEach((track) => {
-                    console.log("venmic: removing existing audio track:", track.label);
-                    stream.removeTrack(track);
-                });
                 const audioTrack = audioStream.getAudioTracks()[0];
-                stream.addTrack(audioTrack);
+                if (audioTrack) {
+                    stream.getAudioTracks().forEach((track) => {
+                        console.debug("venmic: removing existing audio track:", track.label);
+                        stream.removeTrack(track);
+                    });
+                    stream.addTrack(audioTrack);
 
-                // Clean up venmic when the audio track ends
-                audioTrack.addEventListener("ended", () => {
-                    console.log("venmic: audio track ended, stopping venmic");
-                    void ipcRenderer.invoke("stopVenmic");
-                });
-
-                // Also clean up when the video track ends (screen share stopped)
-                const videoTrack = stream.getVideoTracks()[0];
-                if (videoTrack) {
-                    videoTrack.addEventListener("ended", () => {
-                        console.log("venmic: video track ended, stopping venmic");
+                    // Clean up venmic when the audio track ends
+                    audioTrack.addEventListener("ended", () => {
+                        console.debug("venmic: audio track ended, stopping venmic");
                         void ipcRenderer.invoke("stopVenmic");
                     });
-                }
 
-                console.log("venmic: audio track added to screen share stream successfully");
+                    // Also clean up when the video track ends (screen share stopped)
+                    const videoTrack = stream.getVideoTracks()[0];
+                    if (videoTrack) {
+                        videoTrack.addEventListener("ended", () => {
+                            console.debug("venmic: video track ended, stopping venmic");
+                            void ipcRenderer.invoke("stopVenmic");
+                        });
+                    }
+
+                    console.log("venmic: audio track added to screen share stream");
+                } else {
+                    console.warn("venmic: no audio track returned from virtual microphone");
+                }
             } else {
-                console.log("venmic: vencord-screen-share device NOT found");
+                console.debug("venmic: vencord-screen-share device not found, audio not captured");
             }
         } catch (err) {
             console.error("venmic: failed to capture audio from virtual microphone:", err);
         }
 
-        console.log(
+        console.debug(
             "venmic: returning stream with tracks:",
             stream.getTracks().map((t) => `${t.kind}:${t.label}`),
         );

--- a/src/preload.cts
+++ b/src/preload.cts
@@ -167,7 +167,7 @@ if (process.platform === "linux") {
                     // Clean up venmic when the audio track ends
                     audioTrack.addEventListener("ended", () => {
                         console.debug("venmic: audio track ended, stopping venmic");
-                        void ipcRenderer.invoke("stopVenmic");
+                        ipcRenderer.invoke("stopVenmic").catch((e) => console.error("venmic: failed to stop:", e));
                     });
 
                     // Also clean up when the video track ends (screen share stopped)
@@ -175,7 +175,7 @@ if (process.platform === "linux") {
                     if (videoTrack) {
                         videoTrack.addEventListener("ended", () => {
                             console.debug("venmic: video track ended, stopping venmic");
-                            void ipcRenderer.invoke("stopVenmic");
+                            ipcRenderer.invoke("stopVenmic").catch((e) => console.error("venmic: failed to stop:", e));
                         });
                     }
 

--- a/src/preload.cts
+++ b/src/preload.cts
@@ -76,4 +76,30 @@ contextBridge.exposeInMainWorld("electron", {
     async getSettingValue(settingName: string): Promise<any> {
         return ipcRenderer.invoke("getSettingValue", settingName);
     },
+
+    /**
+     * Virtual microphone API for Linux audio sharing via PipeWire.
+     * Only functional on Linux with PipeWire and @vencord/venmic installed.
+     */
+    venmic: {
+        /** List available audio nodes for sharing. */
+        list(): Promise<
+            | { ok: false; isGlibCxxOutdated: boolean }
+            | { ok: true; targets: Record<string, string>[]; hasPipewirePulse: boolean }
+        > {
+            return ipcRenderer.invoke("getVenmicList");
+        },
+        /** Start capturing audio from specific application nodes. */
+        start(include: Record<string, string>[]): Promise<boolean | undefined> {
+            return ipcRenderer.invoke("startVenmic", include);
+        },
+        /** Start capturing system-wide audio, optionally excluding specific nodes. */
+        startSystem(exclude: Record<string, string>[]): Promise<boolean | undefined> {
+            return ipcRenderer.invoke("startVenmicSystem", exclude);
+        },
+        /** Stop the virtual microphone and clean up. */
+        stop(): Promise<void> {
+            return ipcRenderer.invoke("stopVenmic");
+        },
+    },
 });

--- a/src/preload.cts
+++ b/src/preload.cts
@@ -86,7 +86,7 @@ contextBridge.exposeInMainWorld("electron", {
     venmic: {
         /** List available audio nodes for sharing. */
         list(): Promise<
-            | { ok: false; isGlibCxxOutdated: boolean }
+            | { ok: false; isGlibcOutdated: boolean }
             | { ok: true; targets: Record<string, string>[]; hasPipewirePulse: boolean }
         > {
             return ipcRenderer.invoke("getVenmicList");

--- a/src/venmic-inject.ts
+++ b/src/venmic-inject.ts
@@ -25,23 +25,23 @@ const VENMIC_PATCH_SCRIPT = `
     const originalGetDisplayMedia = navigator.mediaDevices.getDisplayMedia.bind(navigator.mediaDevices);
 
     navigator.mediaDevices.getDisplayMedia = async function(options) {
-        console.log('[venmic-inject] getDisplayMedia called in frame:', window.location.href);
+        console.debug('[venmic-inject] getDisplayMedia called in frame:', window.location.href);
         
         const stream = await originalGetDisplayMedia(options);
-        console.log('[venmic-inject] original getDisplayMedia returned, tracks:', 
+        console.debug('[venmic-inject] original getDisplayMedia returned, tracks:', 
             stream.getTracks().map(t => t.kind + ':' + t.label).join(', '));
 
         // Try to find and capture from venmic virtual microphone
         try {
             const devices = await navigator.mediaDevices.enumerateDevices();
             const audioInputs = devices.filter(d => d.kind === 'audioinput');
-            console.log('[venmic-inject] available audio inputs:', 
+            console.debug('[venmic-inject] available audio inputs:', 
                 audioInputs.map(d => d.label || d.deviceId.slice(0, 8)).join(', '));
 
             const venmicDevice = devices.find(d => d.label === 'vencord-screen-share');
 
             if (venmicDevice) {
-                console.log('[venmic-inject] found vencord-screen-share device!');
+                console.debug('[venmic-inject] found vencord-screen-share device');
 
                 const audioStream = await navigator.mediaDevices.getUserMedia({
                     audio: {
@@ -55,32 +55,33 @@ const VENMIC_PATCH_SCRIPT = `
                     }
                 });
 
-                console.log('[venmic-inject] captured audio from venmic virtual mic');
-
-                // Remove any existing audio tracks
-                stream.getAudioTracks().forEach(track => {
-                    console.log('[venmic-inject] removing existing audio track:', track.label);
-                    stream.removeTrack(track);
-                });
-
-                // Add the venmic audio track
                 const audioTrack = audioStream.getAudioTracks()[0];
-                stream.addTrack(audioTrack);
+                if (audioTrack) {
+                    // Remove any existing audio tracks
+                    stream.getAudioTracks().forEach(track => {
+                        console.debug('[venmic-inject] removing existing audio track:', track.label);
+                        stream.removeTrack(track);
+                    });
 
-                console.log('[venmic-inject] venmic audio track added to stream successfully');
+                    // Add the venmic audio track
+                    stream.addTrack(audioTrack);
+                    console.log('[venmic-inject] venmic audio track added to stream');
+                } else {
+                    console.warn('[venmic-inject] no audio track returned from virtual microphone');
+                }
             } else {
-                console.log('[venmic-inject] vencord-screen-share device not found');
+                console.debug('[venmic-inject] vencord-screen-share device not found');
             }
         } catch (err) {
             console.error('[venmic-inject] failed to capture venmic audio:', err);
         }
 
-        console.log('[venmic-inject] returning stream with tracks:', 
+        console.debug('[venmic-inject] returning stream with tracks:', 
             stream.getTracks().map(t => t.kind + ':' + t.label).join(', '));
         return stream;
     };
 
-    console.log('[venmic-inject] getDisplayMedia patch installed in frame:', window.location.href);
+    console.debug('[venmic-inject] getDisplayMedia patch installed in frame:', window.location.href);
 })();
 `;
 
@@ -96,7 +97,7 @@ export function setupVenmicInjection(webContents: WebContents): void {
             if (isMainFrame) {
                 // Main frame - inject directly
                 await webContents.executeJavaScript(VENMIC_PATCH_SCRIPT, true);
-                console.log("venmic: patch injected into main frame");
+                console.debug("venmic: patch injected into main frame");
             } else {
                 // Subframe - need to find and inject into all frames
                 // Get all frames including subframes
@@ -128,7 +129,7 @@ async function injectIntoAllFrames(frame: Electron.WebFrameMain): Promise<void> 
 
         // Inject into this frame
         await frame.executeJavaScript(VENMIC_PATCH_SCRIPT, true);
-        console.log("venmic: patch injected into frame:", frame.url);
+        console.debug("venmic: patch injected into frame:", frame.url);
     } catch (err) {
         // Frame might have been destroyed or navigated
         console.debug("venmic: failed to inject into frame:", err);

--- a/src/venmic-inject.ts
+++ b/src/venmic-inject.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 New Vector Ltd.
+Copyright 2026 Joao Costa <me@joaocosta.dev>
 
 SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
 Please see LICENSE files in the repository root for full details.

--- a/src/venmic-inject.ts
+++ b/src/venmic-inject.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 New Vector Ltd.
+Copyright 2026 New Vector Ltd.
 
 SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
 Please see LICENSE files in the repository root for full details.
@@ -134,8 +134,6 @@ async function injectIntoAllFrames(frame: Electron.WebFrameMain): Promise<void> 
         console.debug("venmic: failed to inject into frame:", err);
     }
 
-    // Inject into child frames
-    for (const childFrame of frame.frames) {
-        await injectIntoAllFrames(childFrame);
-    }
+    // Inject into child frames in parallel
+    await Promise.all(frame.frames.map((childFrame) => injectIntoAllFrames(childFrame)));
 }

--- a/src/venmic-inject.ts
+++ b/src/venmic-inject.ts
@@ -1,0 +1,141 @@
+/*
+Copyright 2025 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+/**
+ * This module injects the venmic getDisplayMedia patch into all frames (including iframes)
+ * so that Element Call can capture audio from the venmic virtual microphone.
+ */
+
+import type { WebContents } from "electron";
+
+/**
+ * JavaScript code to patch getDisplayMedia in the renderer/iframe context.
+ * This is injected into each frame to capture audio from the venmic virtual mic.
+ */
+const VENMIC_PATCH_SCRIPT = `
+(function() {
+    // Only run once per context
+    if (window.__venmicPatched) return;
+    window.__venmicPatched = true;
+
+    const originalGetDisplayMedia = navigator.mediaDevices.getDisplayMedia.bind(navigator.mediaDevices);
+
+    navigator.mediaDevices.getDisplayMedia = async function(options) {
+        console.log('[venmic-inject] getDisplayMedia called in frame:', window.location.href);
+        
+        const stream = await originalGetDisplayMedia(options);
+        console.log('[venmic-inject] original getDisplayMedia returned, tracks:', 
+            stream.getTracks().map(t => t.kind + ':' + t.label).join(', '));
+
+        // Try to find and capture from venmic virtual microphone
+        try {
+            const devices = await navigator.mediaDevices.enumerateDevices();
+            const audioInputs = devices.filter(d => d.kind === 'audioinput');
+            console.log('[venmic-inject] available audio inputs:', 
+                audioInputs.map(d => d.label || d.deviceId.slice(0, 8)).join(', '));
+
+            const venmicDevice = devices.find(d => d.label === 'vencord-screen-share');
+
+            if (venmicDevice) {
+                console.log('[venmic-inject] found vencord-screen-share device!');
+
+                const audioStream = await navigator.mediaDevices.getUserMedia({
+                    audio: {
+                        deviceId: { exact: venmicDevice.deviceId },
+                        autoGainControl: false,
+                        echoCancellation: false,
+                        noiseSuppression: false,
+                        channelCount: 2,
+                        sampleRate: 48000,
+                        sampleSize: 16
+                    }
+                });
+
+                console.log('[venmic-inject] captured audio from venmic virtual mic');
+
+                // Remove any existing audio tracks
+                stream.getAudioTracks().forEach(track => {
+                    console.log('[venmic-inject] removing existing audio track:', track.label);
+                    stream.removeTrack(track);
+                });
+
+                // Add the venmic audio track
+                const audioTrack = audioStream.getAudioTracks()[0];
+                stream.addTrack(audioTrack);
+
+                console.log('[venmic-inject] venmic audio track added to stream successfully');
+            } else {
+                console.log('[venmic-inject] vencord-screen-share device not found');
+            }
+        } catch (err) {
+            console.error('[venmic-inject] failed to capture venmic audio:', err);
+        }
+
+        console.log('[venmic-inject] returning stream with tracks:', 
+            stream.getTracks().map(t => t.kind + ':' + t.label).join(', '));
+        return stream;
+    };
+
+    console.log('[venmic-inject] getDisplayMedia patch installed in frame:', window.location.href);
+})();
+`;
+
+/**
+ * Set up venmic injection for all frames in the given webContents.
+ * This patches getDisplayMedia in both the main frame and all iframes (like Element Call).
+ */
+export function setupVenmicInjection(webContents: WebContents): void {
+    // Inject into frames as they finish loading
+    webContents.on("did-frame-finish-load", async (_event, isMainFrame) => {
+        // We want to inject into all frames, but especially Element Call iframes
+        try {
+            if (isMainFrame) {
+                // Main frame - inject directly
+                await webContents.executeJavaScript(VENMIC_PATCH_SCRIPT, true);
+                console.log("venmic: patch injected into main frame");
+            } else {
+                // Subframe - need to find and inject into all frames
+                // Get all frames including subframes
+                const mainFrame = webContents.mainFrame;
+                if (mainFrame) {
+                    await injectIntoAllFrames(mainFrame);
+                }
+            }
+        } catch (err) {
+            // Ignore errors for frames that might have navigated away
+            console.debug("venmic: failed to inject into frame:", err);
+        }
+    });
+
+    // Also inject into any existing frames
+    const mainFrame = webContents.mainFrame;
+    if (mainFrame) {
+        void injectIntoAllFrames(mainFrame);
+    }
+}
+
+/**
+ * Recursively inject the venmic patch into a frame and all its child frames.
+ */
+async function injectIntoAllFrames(frame: Electron.WebFrameMain): Promise<void> {
+    try {
+        // Check if frame is still valid
+        if (!frame.url) return;
+
+        // Inject into this frame
+        await frame.executeJavaScript(VENMIC_PATCH_SCRIPT, true);
+        console.log("venmic: patch injected into frame:", frame.url);
+    } catch (err) {
+        // Frame might have been destroyed or navigated
+        console.debug("venmic: failed to inject into frame:", err);
+    }
+
+    // Inject into child frames
+    for (const childFrame of frame.frames) {
+        await injectIntoAllFrames(childFrame);
+    }
+}

--- a/src/venmic.ts
+++ b/src/venmic.ts
@@ -24,6 +24,10 @@ let initialized = false;
 let hasPipewirePulse = false;
 let isGlibCxxOutdated = false;
 
+export type VenmicListResult =
+    | { ok: true; targets: Node[]; hasPipewirePulse: boolean }
+    | { ok: false; isGlibCxxOutdated: boolean };
+
 function importVenmic(): void {
     if (imported) {
         return;
@@ -80,7 +84,11 @@ function getRendererAudioServicePid(): string {
     return audioService?.pid?.toString() ?? "";
 }
 
-ipcMain.handle("getVenmicList", () => {
+/**
+ * List available audio nodes for sharing.
+ * Can be called directly from main process code.
+ */
+export function listVenmicNodes(): VenmicListResult {
     const audioPid = getRendererAudioServicePid();
 
     const targets = obtainVenmic()
@@ -88,9 +96,13 @@ ipcMain.handle("getVenmicList", () => {
         .filter((s) => s["application.process.id"] !== audioPid);
 
     return targets ? { ok: true, targets, hasPipewirePulse } : { ok: false, isGlibCxxOutdated };
-});
+}
 
-ipcMain.handle("startVenmic", (_ev, include: Node[]) => {
+/**
+ * Start capturing audio from specific application nodes.
+ * Can be called directly from main process code.
+ */
+export function startVenmicDirect(include: Node[]): boolean | undefined {
     const pid = getRendererAudioServicePid();
 
     const data: LinkData = {
@@ -100,9 +112,13 @@ ipcMain.handle("startVenmic", (_ev, include: Node[]) => {
     };
 
     return obtainVenmic()?.link(data);
-});
+}
 
-ipcMain.handle("startVenmicSystem", (_ev, exclude: Node[]) => {
+/**
+ * Start capturing system-wide audio, optionally excluding specific nodes.
+ * Can be called directly from main process code.
+ */
+export function startVenmicSystemDirect(exclude: Node[]): boolean | undefined {
     const pid = getRendererAudioServicePid();
 
     const data: LinkData = {
@@ -114,6 +130,21 @@ ipcMain.handle("startVenmicSystem", (_ev, exclude: Node[]) => {
     };
 
     return obtainVenmic()?.link(data);
-});
+}
 
-ipcMain.handle("stopVenmic", () => obtainVenmic()?.unlink());
+/**
+ * Stop the virtual microphone and clean up.
+ * Can be called directly from main process code.
+ */
+export function stopVenmicDirect(): void {
+    obtainVenmic()?.unlink();
+}
+
+// IPC handlers for renderer process access
+ipcMain.handle("getVenmicList", () => listVenmicNodes());
+
+ipcMain.handle("startVenmic", (_ev, include: Node[]) => startVenmicDirect(include));
+
+ipcMain.handle("startVenmicSystem", (_ev, exclude: Node[]) => startVenmicSystemDirect(exclude));
+
+ipcMain.handle("stopVenmic", () => stopVenmicDirect());

--- a/src/venmic.ts
+++ b/src/venmic.ts
@@ -12,8 +12,7 @@ import { existsSync } from "node:fs";
 
 import type { LinkData, Node, PatchBay as PatchBayType } from "@vencord/venmic";
 import type { VenmicListResult } from "./@types/audio-sharing.js";
-
-export type { VenmicListResult };
+export type { VenmicListResult } from "./@types/audio-sharing.js";
 
 const nativeRequire = createRequire(import.meta.url);
 

--- a/src/venmic.ts
+++ b/src/venmic.ts
@@ -11,7 +11,6 @@ import { join } from "node:path";
 import { existsSync } from "node:fs";
 
 import type { LinkData, Node, PatchBay as PatchBayType } from "@vencord/venmic";
-
 import type { VenmicListResult } from "./@types/audio-sharing.js";
 
 export type { VenmicListResult };

--- a/src/venmic.ts
+++ b/src/venmic.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 New Vector Ltd.
+Copyright 2026 New Vector Ltd.
 
 SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
 Please see LICENSE files in the repository root for full details.
@@ -22,11 +22,11 @@ let imported = false;
 let initialized = false;
 
 let hasPipewirePulse = false;
-let isGlibCxxOutdated = false;
+let isGlibcOutdated = false;
 
 export type VenmicListResult =
     | { ok: true; targets: Node[]; hasPipewirePulse: boolean }
-    | { ok: false; isGlibCxxOutdated: boolean };
+    | { ok: false; isGlibcOutdated: boolean };
 
 function importVenmic(): void {
     if (imported) {
@@ -36,25 +36,15 @@ function importVenmic(): void {
     imported = true;
 
     try {
-        // Load the native .node file directly to avoid needing the full
-        // venmic JS entry point and its pkg-prebuilds dependency chain in the
-        // packaged app. This follows the same approach used by Vesktop.
-        const nativePath = join(
-            __dirname,
-            "..",
-            "node_modules",
-            "@vencord",
-            "venmic",
-            "prebuilds",
-            `venmic-addon-linux-${process.arch}`,
-            "node-napi-v7.node",
-        );
+        // Load the native .node file directly from lib/ where it's copied
+        // during build. This follows the same approach used by Vesktop.
+        const nativePath = join(__dirname, `venmic-${process.arch}.node`);
         PatchBay = (nativeRequire(nativePath) as { PatchBay: typeof PatchBayType }).PatchBay;
         hasPipewirePulse = PatchBay.hasPipeWire();
     } catch (e: unknown) {
         const message = e instanceof Error ? (e.stack ?? e.message) : String(e);
         console.error("Failed to import venmic:", message);
-        isGlibCxxOutdated = /GLIBC_\d/.test(message);
+        isGlibcOutdated = message.toLowerCase().includes("glibc");
     }
 }
 
@@ -95,7 +85,7 @@ export function listVenmicNodes(): VenmicListResult {
         ?.list()
         .filter((s) => s["application.process.id"] !== audioPid);
 
-    return targets ? { ok: true, targets, hasPipewirePulse } : { ok: false, isGlibCxxOutdated };
+    return targets ? { ok: true, targets, hasPipewirePulse } : { ok: false, isGlibcOutdated };
 }
 
 /**

--- a/src/venmic.ts
+++ b/src/venmic.ts
@@ -1,0 +1,119 @@
+/*
+Copyright 2025 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import { app, ipcMain } from "electron";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type { LinkData, Node, PatchBay as PatchBayType } from "@vencord/venmic";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const nativeRequire = createRequire(import.meta.url);
+
+let PatchBay: typeof PatchBayType | undefined;
+let patchBayInstance: PatchBayType | undefined;
+
+let imported = false;
+let initialized = false;
+
+let hasPipewirePulse = false;
+let isGlibCxxOutdated = false;
+
+function importVenmic(): void {
+    if (imported) {
+        return;
+    }
+
+    imported = true;
+
+    try {
+        // Load the native .node file directly to avoid needing the full
+        // venmic JS entry point and its pkg-prebuilds dependency chain in the
+        // packaged app. This follows the same approach used by Vesktop.
+        const nativePath = join(
+            __dirname,
+            "..",
+            "node_modules",
+            "@vencord",
+            "venmic",
+            "prebuilds",
+            `venmic-addon-linux-${process.arch}`,
+            "node-napi-v7.node",
+        );
+        PatchBay = (nativeRequire(nativePath) as { PatchBay: typeof PatchBayType }).PatchBay;
+        hasPipewirePulse = PatchBay.hasPipeWire();
+    } catch (e: unknown) {
+        const message = e instanceof Error ? (e.stack ?? e.message) : String(e);
+        console.error("Failed to import venmic:", message);
+        isGlibCxxOutdated = /GLIBC_\d/.test(message);
+    }
+}
+
+function obtainVenmic(): PatchBayType | undefined {
+    if (!imported) {
+        importVenmic();
+    }
+
+    if (PatchBay && !initialized) {
+        initialized = true;
+
+        try {
+            patchBayInstance = new PatchBay();
+        } catch (e) {
+            console.error("Failed to instantiate venmic:", e);
+        }
+    }
+
+    return patchBayInstance;
+}
+
+function getRendererAudioServicePid(): string {
+    const audioService = app.getAppMetrics().find((proc) => proc.name === "Audio Service");
+    if (!audioService) {
+        console.warn("venmic: could not find Audio Service process for filtering");
+    }
+    return audioService?.pid?.toString() ?? "";
+}
+
+ipcMain.handle("getVenmicList", () => {
+    const audioPid = getRendererAudioServicePid();
+
+    const targets = obtainVenmic()
+        ?.list()
+        .filter((s) => s["application.process.id"] !== audioPid);
+
+    return targets ? { ok: true, targets, hasPipewirePulse } : { ok: false, isGlibCxxOutdated };
+});
+
+ipcMain.handle("startVenmic", (_ev, include: Node[]) => {
+    const pid = getRendererAudioServicePid();
+
+    const data: LinkData = {
+        include,
+        exclude: [{ "application.process.id": pid }, { "media.class": "Stream/Input/Audio" }],
+        ignore_devices: true,
+    };
+
+    return obtainVenmic()?.link(data);
+});
+
+ipcMain.handle("startVenmicSystem", (_ev, exclude: Node[]) => {
+    const pid = getRendererAudioServicePid();
+
+    const data: LinkData = {
+        include: [],
+        exclude: [{ "application.process.id": pid }, { "media.class": "Stream/Input/Audio" }, ...exclude],
+        only_speakers: true,
+        only_default_speakers: true,
+        ignore_devices: true,
+    };
+
+    return obtainVenmic()?.link(data);
+});
+
+ipcMain.handle("stopVenmic", () => obtainVenmic()?.unlink());

--- a/src/venmic.ts
+++ b/src/venmic.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 New Vector Ltd.
+Copyright 2026 Joao Costa <me@joaocosta.dev>
 
 SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
 Please see LICENSE files in the repository root for full details.

--- a/src/venmic.ts
+++ b/src/venmic.ts
@@ -7,8 +7,8 @@ Please see LICENSE files in the repository root for full details.
 
 import { app, ipcMain } from "electron";
 import { createRequire } from "node:module";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+import { existsSync } from "node:fs";
 
 import type { LinkData, Node, PatchBay as PatchBayType } from "@vencord/venmic";
 
@@ -16,7 +16,6 @@ import type { VenmicListResult } from "./@types/audio-sharing.js";
 
 export type { VenmicListResult };
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
 const nativeRequire = createRequire(import.meta.url);
 
 let PatchBay: typeof PatchBayType | undefined;
@@ -36,9 +35,14 @@ function importVenmic(): void {
     imported = true;
 
     try {
-        // Load the native .node file directly from lib/ where it's copied
-        // during build. This follows the same approach used by Vesktop.
-        const nativePath = join(__dirname, `venmic-${process.arch}.node`);
+        // Load the native .node file from the HAK output.
+        // In development: .hak/hakModules/@vencord/venmic/venmic.node
+        // When packaged: node_modules/@vencord/venmic/venmic.node (electron-builder copies hakModules there)
+        const appPath = app.getAppPath();
+        const hakPath = join(appPath, ".hak", "hakModules", "@vencord", "venmic", "venmic.node");
+        const packagedPath = join(appPath, "node_modules", "@vencord", "venmic", "venmic.node");
+
+        const nativePath = existsSync(hakPath) ? hakPath : packagedPath;
         PatchBay = (nativeRequire(nativePath) as { PatchBay: typeof PatchBayType }).PatchBay;
         hasPipewirePulse = PatchBay.hasPipeWire();
     } catch (e: unknown) {

--- a/src/venmic.ts
+++ b/src/venmic.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 New Vector Ltd.
+Copyright 2025 New Vector Ltd.
 
 SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
 Please see LICENSE files in the repository root for full details.
@@ -12,6 +12,10 @@ import { fileURLToPath } from "node:url";
 
 import type { LinkData, Node, PatchBay as PatchBayType } from "@vencord/venmic";
 
+import type { VenmicListResult } from "./@types/audio-sharing.js";
+
+export type { VenmicListResult };
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const nativeRequire = createRequire(import.meta.url);
 
@@ -23,10 +27,6 @@ let initialized = false;
 
 let hasPipewirePulse = false;
 let isGlibcOutdated = false;
-
-export type VenmicListResult =
-    | { ok: true; targets: Node[]; hasPipewirePulse: boolean }
-    | { ok: false; isGlibcOutdated: boolean };
 
 function importVenmic(): void {
     if (imported) {

--- a/src/webcontents-handler.ts
+++ b/src/webcontents-handler.ts
@@ -23,10 +23,11 @@ import {
 } from "electron";
 import url from "node:url";
 import fs from "node:fs";
+import path from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
-import path from "node:path";
 
+import type { ReadableStream as WebReadableStream } from "node:stream/web";
 import { _t } from "./language-helper.js";
 
 const MAILTO_PREFIX = "mailto:";
@@ -157,7 +158,7 @@ function onLinkContextMenu(ev: Event, params: ContextMenuParams, webContents: We
                             if (!resp.ok) throw new Error(`unexpected response ${resp.statusText}`);
                             if (!resp.body) throw new Error(`unexpected response has no body ${resp.statusText}`);
                             await pipeline(
-                                Readable.fromWeb(resp.body as import("stream/web").ReadableStream),
+                                Readable.fromWeb(resp.body as WebReadableStream),
                                 fs.createWriteStream(filePath),
                             );
                         }

--- a/src/webcontents-handler.ts
+++ b/src/webcontents-handler.ts
@@ -23,6 +23,7 @@ import {
 } from "electron";
 import url from "node:url";
 import fs from "node:fs";
+import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import path from "node:path";
 
@@ -155,7 +156,10 @@ function onLinkContextMenu(ev: Event, params: ContextMenuParams, webContents: We
                             const resp = await fetch(url);
                             if (!resp.ok) throw new Error(`unexpected response ${resp.statusText}`);
                             if (!resp.body) throw new Error(`unexpected response has no body ${resp.statusText}`);
-                            await pipeline(resp.body, fs.createWriteStream(filePath));
+                            await pipeline(
+                                Readable.fromWeb(resp.body as import("stream/web").ReadableStream),
+                                fs.createWriteStream(filePath),
+                            );
                         }
                     } catch (err) {
                         console.error(err);


### PR DESCRIPTION
## Checklist

- [x] Ensure your code works with manual testing.
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-desktop)

## Description

- This adds support for streaming application audio during screenshares on Linux systems using PipeWire:
  - Mostly Wayland, but works the same on X11 as long as PipeWire is available/in use.
- Uses [venmic](https://github.com/Vencord/venmic) which is a package used by vesktop
  - Vesktop is custom 3rd party discord client
  - It allows screenshares with audio in Linux
- Feature kept as optional:
  - Only works when in Linux, with Pipewire.
  - If venmic fails to load (outdated glibc, missing PipeWire, etc.), the screen share works normally without audio
  
Will help implement the feature requested in this issue: [element-hq/element-call #3657](https://github.com/element-hq/element-call/issues/3657).

## Problems

- I've never loaded a prebuilt node module like this, so I'm not too sure I'm doing it right.
- I was expecting an easier/better way to load the audio source/channel/node picker dialog window
  - Open to suggestions here.
- Venmic isn't exactly intended to be used in other apps like this, but it seems fine to me.

## Next steps (outside the scope of this PR)

- Screenshares currenly lack audio volume controls:
  - Need to check that the audio is being sent as a separate stream and add a volume slider for it.
- Get something similar working on Windows and on MacOS.

## Screenshots

Audio sharing screen:

<img width="420" height="549" alt="image" src="https://github.com/user-attachments/assets/37417099-2074-41d0-8310-32308443eb06" />
